### PR TITLE
Use error dialog instead of showing error in main view

### DIFF
--- a/actions/files.js
+++ b/actions/files.js
@@ -50,8 +50,8 @@ function displayFileError(err, dispatch) {
     const error = `Could not open .hex file: ${err}`;
     logger.error(error);
     dispatch({
-        type: 'FILE_ERROR',
-        fileError: error,
+        type: 'ERROR_DIALOG_SHOW',
+        message: error,
     });
 }
 

--- a/components/FileLegend.jsx
+++ b/components/FileLegend.jsx
@@ -94,13 +94,6 @@ function drawFileLegend(container, fileColours) {
 
 const FileLegend = props => {
     const { fileColours } = props;
-/*
-    if (fileError) {
-        return (
-            <div>{ fileError }</div>
-        );
-    } */
-
     return (
         <table
             ref={el => { drawFileLegend(el, fileColours); }}

--- a/components/MemoryLayout.jsx
+++ b/components/MemoryLayout.jsx
@@ -269,18 +269,11 @@ const MemoryLayout = props => {
     const {
         targetSize,
         blockSets,
-        fileError,
         fileColours,
         writtenAddress,
         labels,
         regions,
     } = props;
-
-    if (fileError) {
-        return (
-            <div className="alert alert-error">{ fileError }</div>
-        );
-    }
 
     // Symbolize code region 0 / readback-protected region
     const symbolRegions = Object.entries(regions).map(([region, length]) => {
@@ -317,7 +310,6 @@ MemoryLayout.propTypes = {
     blockSets: PropTypes.instanceOf(Map),
     fileColours: PropTypes.instanceOf(Map),
     writtenAddress: PropTypes.number,
-    fileError: PropTypes.string,
     labels: PropTypes.shape({}),
     regions: PropTypes.shape({}),
 };
@@ -328,7 +320,6 @@ MemoryLayout.defaultProps = {
     blockSets: new Map(),
     fileColours: new Map(),
     writtenAddress: 0,  // From 0 to here will be assumed written, from here to the top pending
-    fileError: null,
     labels: {},
     regions: {},
 };

--- a/containers/appMainView.jsx
+++ b/containers/appMainView.jsx
@@ -41,13 +41,7 @@ import MemoryLayout from '../components/MemoryLayout';
 
 const AppMainView = (
     props => {
-        const { fileError, loaded, targetSize } = props;
-        if (fileError) {
-            return (
-                <div className="alert alert-error">{ fileError }</div>
-            );
-        }
-
+        const { loaded, targetSize } = props;
         return (
             <MemoryLayout {...loaded} targetSize={targetSize} />
         );
@@ -55,13 +49,8 @@ const AppMainView = (
 );
 
 AppMainView.propTypes = {
-    fileError: PropTypes.string,
     loaded: PropTypes.shape({}).isRequired,
     targetSize: PropTypes.number.isRequired,
-};
-
-AppMainView.defaultProps = {
-    fileError: null,
 };
 
 export default connect(
@@ -69,6 +58,5 @@ export default connect(
         ...props,
         loaded: state.app.file.loaded,
         targetSize: state.app.target.size,
-        fileError: state.app.file.fileError,
     }),
 )(AppMainView);

--- a/reducers/fileReducer.js
+++ b/reducers/fileReducer.js
@@ -56,8 +56,6 @@ const colours = [
 ];
 
 const initialState = {
-    fileError: null,
-
     loaded: {
         blockSets: new Map(),
         filenames: [],
@@ -76,7 +74,6 @@ export default function reducer(state = initialState, action) {
         case 'EMPTY_FILES':
             return {
                 ...state,
-                fileError: null,
                 loaded: {
                     blockSets: new Map(),
                     filenames: [],
@@ -86,11 +83,6 @@ export default function reducer(state = initialState, action) {
                     regions: {},
                     labels: {},
                 },
-            };
-        case 'FILE_ERROR':
-            return {
-                ...state,
-                fileError: action.fileError,
             };
         case 'FILE_PARSE': {
             const { loaded } = state;


### PR DESCRIPTION
Now opening an error dialog instead of showing errors in the main view. This way the memory layout is not hidden if an error occurs.