### PR TITLE
Make sure all dependencies are included

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,15 @@
   },
   "devDependencies": {
     "babel-loader": "^7.1.2",
+    "nrf-intel-hex": "^1.0.1",
     "pc-nrfconnect-devdep": "https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#v1.0.0"
   },
   "dependencies": {
-    "electron-store": "^1.2.0",
-    "nrf-intel-hex": "^1.0.1"
+    "electron-store": "^1.2.0"
   },
+  "bundledDependencies": [
+    "electron-store"
+  ],
   "jest": {
     "moduleNameMapper": {
       "nrfconnect/core": "<rootDir>/mocks/coreMock.js"


### PR DESCRIPTION
When packaging this as an app, we need to make sure that all dependencies are included in the tarball. Normally, webpack will include dependencies in the dist/bundle.js that is created at build time. This means that most dependencies can be added as `devDependencies`, as they are only needed when building the app.

However, there may be cases where webpack is not able to parse the dependency. F.ex. the electron-store library depends on the conf library, which webpack has problems parsing. In such cases, we can add it to `dependencies` and `bundledDependencies`, so that it is fully included in `node_modules` in the tarball.

Relevant documentation: https://github.com/NordicSemiconductor/pc-nrfconnect-core/wiki/Configuration#dependencies