### PR TITLE
Feature: remove individual files

### DIFF
--- a/components/ControlPanel.jsx
+++ b/components/ControlPanel.jsx
@@ -118,7 +118,7 @@ const ControlPanel = props => {
                 <Glyphicon glyph="remove-sign" />Recover (full erase)
             </Button>
 
-            <FileLegend fileColours={props.loaded.fileColours} />
+            <FileLegend fileColours={props.loaded.fileColours} remove={props.removeFile} />
 
             { overlapWarning }
             { outsideFlashWarning }
@@ -140,6 +140,7 @@ ControlPanel.propTypes = {
     targetSize: PropTypes.number.isRequired,
     refreshAllFiles: PropTypes.func.isRequired,
     targetIsReady: PropTypes.bool.isRequired,
+    removeFile: PropTypes.func.isRequired,
 };
 
 export default ControlPanel;

--- a/components/FileLegend.jsx
+++ b/components/FileLegend.jsx
@@ -36,9 +36,11 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Glyphicon } from 'react-bootstrap';
+import { basename } from 'path';
 
 const FileLegend = props => {
-    const { fileColours } = props;
+    const { fileColours, remove } = props;
     const fileColourArray = Array.from(fileColours);
     return (
         <table className="file-legend">
@@ -52,8 +54,15 @@ const FileLegend = props => {
                                     style={{ backgroundColor: colour }}
                                 />
                             </td>
-                            <td title={filename} className="file-label">
-                                { filename }
+                            <td title={basename(filename)} className="file-label">
+                                { basename(filename) }
+                            </td>
+                            <td>
+                                <Glyphicon
+                                    glyph="remove-sign"
+                                    onClick={() => { remove(filename); }}
+                                    title="Remove this file"
+                                />
                             </td>
                         </tr>
                     ))
@@ -65,6 +74,7 @@ const FileLegend = props => {
 
 FileLegend.propTypes = {
     fileColours: PropTypes.instanceOf(Map),
+    remove: PropTypes.func.isRequired,
 };
 
 FileLegend.defaultProps = {

--- a/containers/appMainView.jsx
+++ b/containers/appMainView.jsx
@@ -67,6 +67,16 @@ const AppMainView = (
             targetMap = <div className="memlayout-spinner" />;
         }
 
+        const inverseLabels = {};
+        loaded.fileLabels.forEach(fileLabels => {
+            Object.entries(fileLabels).forEach(([label, addr]) => {
+                inverseLabels[addr] = label;
+            });
+        });
+        const labels = {};
+        Object.entries(inverseLabels).forEach(([addr, label]) => {
+            labels[label] = addr;
+        });
 
         return (
             <div style={{
@@ -93,7 +103,7 @@ const AppMainView = (
                     width: '50%',
                 }}
                 >
-                    <MemoryLayout {...loaded} targetSize={target.size} />
+                    <MemoryLayout {...loaded} labels={labels} targetSize={target.size} />
                 </div>
             </div>
         );

--- a/containers/controlPanel.js
+++ b/containers/controlPanel.js
@@ -55,5 +55,6 @@ export default connect(
         performWrite: () => { dispatch({ type: 'START_WRITE' }); },
         performRecover: () => { dispatch({ type: 'START_RECOVER' }); },
         closeFiles: () => { dispatch({ type: 'EMPTY_FILES' }); },
+        removeFile: filePath => { dispatch({ type: 'REMOVE_FILE', filePath }); },
     }),
 )(ControlPanel);


### PR DESCRIPTION
An alternative to #18, which implements the "remove individual files" feature, doesn't need restructuring the code, doesn't need any updates to the `MemoryLayout`, and ensures that only known colours are used, and that if there are less loaded files than available colours, no colours are repeated.