### PR TITLE
Use the right product ID for Segger devices

### DIFF
--- a/lib/util/devices.js
+++ b/lib/util/devices.js
@@ -120,7 +120,7 @@ export const VendorId = {
 };
 
 export const ProductId = {
-    SEGGER: 0x1015,
+    SEGGER: 0x0105,
     NRF521F: 0x521F,
 };
 


### PR DESCRIPTION
Got "unsupported device" when selecting a nRF51/nRF52 kit. Seems that the product ID was incorrect.