### PR TITLE
Rename port→jlink, usb→usbsdfu. Grammar fixes in log messages.

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -41,8 +41,8 @@ import ControlPanel from './lib/containers/controlPanel';
 import AppMainView from './lib/containers/appMainView';
 import * as fileActions from './lib/actions/fileActions';
 import * as targetActions from './lib/actions/targetActions';
-import * as portTargetActions from './lib/actions/portTargetActions';
-import * as usbTargetActions from './lib/actions/usbTargetActions';
+import * as jlinkTargetActions from './lib/actions/jlinkTargetActions';
+import * as usbsdfuTargetActions from './lib/actions/usbsdfuTargetActions';
 import appReducer from './lib/reducers';
 import { VendorId, USBProductIds, JlinkProductIds, CommunicationType } from './lib/util/devices';
 import { hexpad4 } from './lib/util/hexpad';
@@ -109,10 +109,10 @@ export default {
                 const vid = parseInt(vendorId.toString(16), 16);
                 const pid = parseInt(productId.toString(16), 16);
                 if (vid === VendorId.SEGGER && JlinkProductIds.includes(pid)) {
-                    dispatch(portTargetActions.loadDeviceInfo(serialNumber));
+                    dispatch(jlinkTargetActions.loadDeviceInfo(serialNumber));
                 } else if (vid === VendorId.NORDIC_SEMICONDUCTOR &&
                            USBProductIds.includes(pid)) {
-                    dispatch(usbTargetActions.openDevice(action.device));
+                    dispatch(usbsdfuTargetActions.openDevice(action.device));
                 } else {
                     logger.error(`Unsupported device (vendorId: ${hexpad4(vid)}, productId: ${hexpad4(pid)})`);
                 }
@@ -130,15 +130,15 @@ export default {
                 if (state.app.file.memMaps.length === 0) {
                     return;
                 }
-                if (state.app.target.targetType === CommunicationType.PORT) {
-                    dispatch(portTargetActions.write());
-                } else if (state.app.target.targetType === CommunicationType.USB) {
-                    dispatch(usbTargetActions.write());
+                if (state.app.target.targetType === CommunicationType.JLINK) {
+                    dispatch(jlinkTargetActions.write());
+                } else if (state.app.target.targetType === CommunicationType.USBSDFU) {
+                    dispatch(usbsdfuTargetActions.write());
                 }
                 break;
             }
             case targetActions.RECOVER_START: {
-                dispatch(portTargetActions.recover());
+                dispatch(jlinkTargetActions.recover());
                 break;
             }
             case targetActions.REFRESH_ALL_FILES_START: {

--- a/lib/actions/jlinkTargetActions.js
+++ b/lib/actions/jlinkTargetActions.js
@@ -248,8 +248,8 @@ export function updateTargetRegions(regionsInput, memMap) {
 export function loadDeviceInfo(serialNumberInput, refresh = false) {
     return async (dispatch, getState) => {
         dispatch(targetActions.targetWarningKnownAction());
-        dispatch(targetActions.targetTypeKnownAction(devices.CommunicationType.PORT, true));
-        logger.info('Target device has the communication type of serial port');
+        dispatch(targetActions.targetTypeKnownAction(devices.CommunicationType.JLINK, true));
+        logger.info('Using nrfjprog to communicate with target');
 
         const serialNumber = parseInt(serialNumberInput, 10);
         let info;

--- a/lib/actions/targetActions.js
+++ b/lib/actions/targetActions.js
@@ -35,8 +35,8 @@
  */
 
 import { List } from 'immutable';
-import * as portTargetActions from './portTargetActions';
-import * as usbTargetActions from './usbTargetActions';
+import * as jlinkTargetActions from './jlinkTargetActions';
+import * as usbsdfuTargetActions from './usbsdfuTargetActions';
 import { CommunicationType } from '../util/devices';
 
 export const TARGET_TYPE_KNOWN = 'TARGET_TYPE_KNOWN';
@@ -210,11 +210,11 @@ export function targetPortChanged(serialNumber, comName) {
 export function updateTargetWritable() {
     return (dispatch, getState) => {
         switch (getState().app.target.targetType) {
-            case CommunicationType.PORT:
-                dispatch(portTargetActions.canWrite());
+            case CommunicationType.JLINK:
+                dispatch(jlinkTargetActions.canWrite());
                 break;
-            case CommunicationType.USB:
-                dispatch(usbTargetActions.canWrite());
+            case CommunicationType.USBSDFU:
+                dispatch(usbsdfuTargetActions.canWrite());
                 break;
             default:
                 dispatch(targetWarningKnownAction('Target type is unknown'));

--- a/lib/actions/usbsdfuTargetActions.js
+++ b/lib/actions/usbsdfuTargetActions.js
@@ -88,7 +88,7 @@ function loadDeviceInfo(selectedDevice) {
         const { comName } = selectedDevice.serialport;
         dispatch(targetActions.targetWarningKnownAction());
         dispatch(targetActions.targetTypeKnownAction(devices.CommunicationType.USB, false));
-        logger.info('Target device has the communication type of USB');
+        logger.info('Using USB SDFU protocol to communicate with target');
 
         try {
             const { hardwareVersion, firmwareVersions } = await getDeviceVersions(comName);

--- a/lib/containers/appMainView.js
+++ b/lib/containers/appMainView.js
@@ -36,7 +36,7 @@
 
 import { connect } from 'react-redux';
 import AppMainView from '../components/AppMainView';
-import * as portTargetActions from '../actions/portTargetActions';
+import * as jlinkTargetActions from '../actions/jlinkTargetActions';
 import { CommunicationType } from '../util/devices';
 
 export default connect(
@@ -44,10 +44,10 @@ export default connect(
         ...props,
         file: state.app.file,
         target: state.app.target,
-        refreshEnabled: state.app.target.targetType === CommunicationType.PORT,
+        refreshEnabled: state.app.target.targetType === CommunicationType.JLINK,
     }),
     (dispatch, props) => ({
         ...props,
-        refreshTargetContents: () => dispatch(portTargetActions.refreshTargetContents()),
+        refreshTargetContents: () => dispatch(jlinkTargetActions.refreshTargetContents()),
     }),
 )(AppMainView);

--- a/lib/util/devices.js
+++ b/lib/util/devices.js
@@ -135,8 +135,8 @@ export const JlinkProductIds = [
 
 export const CommunicationType = {
     UNKNOWN: 0,
-    PORT: 1,
-    USB: 2,
+    JLINK: 1,
+    USBSDFU: 2,
 };
 
 // Device variants from jprog.


### PR DESCRIPTION
Rename some variables and files. The terms "port" and "usb" are too generic and IMO they don't reflect the concepts that the programmer works with.

Also changed the wording of the `Target device has the communication type of` log messages.

Please note that this PR targets the `feature/device-selector` branch and not `master`, as #50 hasn't been merged yet.