### PR TITLE
Fix/memory region detection

### DIFF
--- a/lib/actions/jlinkTargetActions.js
+++ b/lib/actions/jlinkTargetActions.js
@@ -34,12 +34,11 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { List } from 'immutable';
 import { logger } from 'nrfconnect/core';
 import nrfjprog from 'pc-nrfjprog-js';
 import MemoryMap from 'nrf-intel-hex';
 import { checkUpToDateFiles } from './fileActions';
-import { Region, getMemoryRegions, RegionPermission } from '../util/regions';
+import { getMemoryRegions, getTargetRegions } from '../util/regions';
 import * as targetActions from './targetActions';
 import * as devices from '../util/devices';
 
@@ -202,47 +201,9 @@ export function updateTargetRegions(regionsInput, memMap, deviceInfo) {
             colour: '#C0C0C0',
             writtenAddress: 0,
         };
-        const loaded = { targetDevice };
         const memMaps = [['targetDevice', memMap]];
-        const overlaps = MemoryMap.overlapMemoryMaps(memMaps);
-        let regions = new List();
-
-        // Display the real memory even though some regions are meaningless
-        overlaps.forEach((overlap, startAddress) => {
-            // Draw a solid block (with one solid colour or more striped colours)
-            let regionSize = 0;
-            const colours = [];
-            overlap.forEach(([filename, bytes]) => {
-                regionSize = bytes.length;
-                colours.push(loaded[filename].colour);
-            });
-
-            let region = regionsInput.find(r =>
-                r.startAddress >= startAddress &&
-                r.startAddress <= startAddress + regionSize);
-
-            if (region) {
-                region = region
-                    .set('startAddress', startAddress)
-                    .set('regionSize', regionSize)
-                    .set('colours', colours);
-            } else {
-                region = new Region({
-                    startAddress,
-                    regionSize,
-                    permisstion: RegionPermission.READ_WRITE,
-                });
-                // When writing some certain .hex files to device,
-                // it writes some extra bytes which are not applications
-                // between the addresses from max size - 0x3000 to max size.
-                // TODO: figure out why it writes some extra bytes there and
-                // fix the magic number.
-                if (region.startAddress < deviceInfo.romSize - 0x3000) {
-                    region = region.set('name', 'Application (Probably)');
-                }
-            }
-            regions = regions.push(region);
-        });
+        const loadedDevice = { targetDevice };
+        const regions = getTargetRegions(memMaps, loadedDevice, deviceInfo);
 
         dispatch(targetActions.targetRegionsKnownAction(regions));
     };

--- a/lib/actions/jlinkTargetActions.js
+++ b/lib/actions/jlinkTargetActions.js
@@ -219,10 +219,13 @@ export function updateTargetRegions(regionsInput, memMap) {
                     colours.push(loaded[filename].colour);
                 });
 
-                let region = regionsInput.find(
-                    r => (r.startAddress === startAddress));
+                let region = regionsInput.find(r =>
+                    r.startAddress >= startAddress &&
+                    r.startAddress <= startAddress + regionSize);
+
                 if (region) {
                     region = region
+                        .set('startAddress', startAddress)
                         .set('regionSize', regionSize)
                         .set('colours', colours);
                 } else {

--- a/lib/actions/jlinkTargetActions.js
+++ b/lib/actions/jlinkTargetActions.js
@@ -232,10 +232,11 @@ export function updateTargetRegions(regionsInput, memMap, deviceInfo) {
                     regionSize,
                     permisstion: RegionPermission.READ_WRITE,
                 });
-                // When writing SoftDevice to device, it writes some extra bytes
-                // which are not application
-                // between the max size and max size - 0x3000
-                // TODO: figure out why it writes some extra bytes there.
+                // When writing some certain .hex files to device,
+                // it writes some extra bytes which are not applications
+                // between the addresses from max size - 0x3000 to max size.
+                // TODO: figure out why it writes some extra bytes there and
+                // fix the magic number.
                 if (region.startAddress < deviceInfo.romSize - 0x3000) {
                     region = region.set('name', 'Application (Probably)');
                 }

--- a/lib/actions/jlinkTargetActions.js
+++ b/lib/actions/jlinkTargetActions.js
@@ -195,7 +195,7 @@ export function canWrite() {
 }
 
 // Update infos of the target regions
-export function updateTargetRegions(regionsInput, memMap) {
+export function updateTargetRegions(regionsInput, memMap, deviceInfo) {
     return dispatch => {
         const targetDevice = {
             filename: 'targetDevice',
@@ -206,41 +206,42 @@ export function updateTargetRegions(regionsInput, memMap) {
         const memMaps = [['targetDevice', memMap]];
         const overlaps = MemoryMap.overlapMemoryMaps(memMaps);
         let regions = new List();
-        const bootloaderRegion = regions.find(region => region.name === 'bootloader');
 
         // Display the real memory even though some regions are meaningless
-        if (regionsInput.size) {
-            overlaps.forEach((overlap, startAddress) => {
-                // Draw a solid block (with one solid colour or more striped colours)
-                let regionSize = 0;
-                const colours = [];
-                overlap.forEach(([filename, bytes]) => {
-                    regionSize = bytes.length;
-                    colours.push(loaded[filename].colour);
-                });
-
-                let region = regionsInput.find(r =>
-                    r.startAddress >= startAddress &&
-                    r.startAddress <= startAddress + regionSize);
-
-                if (region) {
-                    region = region
-                        .set('startAddress', startAddress)
-                        .set('regionSize', regionSize)
-                        .set('colours', colours);
-                } else {
-                    region = new Region({
-                        startAddress,
-                        regionSize,
-                        permisstion: RegionPermission.READ_WRITE,
-                    });
-                    if (bootloaderRegion && region.address < bootloaderRegion.address) {
-                        region = region.set('name', 'Application (Probably)');
-                    }
-                }
-                regions = regions.push(region);
+        overlaps.forEach((overlap, startAddress) => {
+            // Draw a solid block (with one solid colour or more striped colours)
+            let regionSize = 0;
+            const colours = [];
+            overlap.forEach(([filename, bytes]) => {
+                regionSize = bytes.length;
+                colours.push(loaded[filename].colour);
             });
-        }
+
+            let region = regionsInput.find(r =>
+                r.startAddress >= startAddress &&
+                r.startAddress <= startAddress + regionSize);
+
+            if (region) {
+                region = region
+                    .set('startAddress', startAddress)
+                    .set('regionSize', regionSize)
+                    .set('colours', colours);
+            } else {
+                region = new Region({
+                    startAddress,
+                    regionSize,
+                    permisstion: RegionPermission.READ_WRITE,
+                });
+                // When writing SoftDevice to device, it writes some extra bytes
+                // which are not application
+                // between the max size and max size - 0x3000
+                // TODO: figure out why it writes some extra bytes there.
+                if (region.startAddress < deviceInfo.romSize - 0x3000) {
+                    region = region.set('name', 'Application (Probably)');
+                }
+            }
+            regions = regions.push(region);
+        });
 
         dispatch(targetActions.targetRegionsKnownAction(regions));
     };
@@ -277,7 +278,7 @@ export function loadDeviceInfo(serialNumberInput, refresh = false) {
         }
         const regions = getMemoryRegions(memMap, deviceInfo);
         dispatch(targetActions.targetContentsKnownAction(memMap));
-        dispatch(updateTargetRegions(regions, memMap));
+        dispatch(updateTargetRegions(regions, memMap, deviceInfo));
         dispatch(targetActions.updateTargetWritable());
     };
 }

--- a/lib/util/devices.js
+++ b/lib/util/devices.js
@@ -47,8 +47,8 @@ export const DeviceDefinition = Record({
     romBaseAddr: 0x0,
     romSize: 0x100000, // 1 MB
     ramSize: null,
-    pageSize: 0x4,  // 4 KB
-    blockSize: 0.5, // KB
+    pageSize: 0x1000,  // 4 KB
+    blockSize: 0x200, // 0.5 KB
     ficrBaseAddr: 0x10000000,
     ficrSize: 0x400, // Todo: check and make sure!
     uicrBaseAddr: 0x10001000,

--- a/lib/util/regions.js
+++ b/lib/util/regions.js
@@ -280,12 +280,13 @@ export function getMemoryRegions(memMap, deviceInfo) {
 }
 
 /**
- * Given an instance of MemoryMap and DeviceDefinition,
- * return the heuristically detected regions for loaded files.
+ * Given overlaps of memory content of either files or device,
+ * the loaded memory content and DeviceDefinition,
+ * return the heuristically detected regions for loaded memory contents.
  *
- * @param {Array}              memMaps      the memory map
- * @param {Hex}                loadedFiles  the loaded files
- * @param {DeviceDefinition}   deviceInfo   the device infomation
+ * @param {Array}              overlaps      the overlaps
+ * @param {Hex}                loadedContent the loaded content
+ * @param {DeviceDefinition}   deviceInfo    the device infomation
  *
  * @returns {List} the list of region
  */
@@ -309,18 +310,13 @@ export function getRegionsFromOverlaps(overlaps, loadedContent, deviceInfo) {
         region = memRegions.find(r =>
             r.startAddress >= startAddress &&
             r.startAddress <= startAddress + regionSize);
-        // Assume application never comes on top of bootloader
-        const bootloaderRegion = memRegions.find(r => r.name === RegionName.BOOTLOADER);
-        let regionName = overlap.length === 1 ? RegionName.APPLICATION : RegionName.NONE;
-        regionName = bootloaderRegion &&
-            startAddress > bootloaderRegion.startAddress ?
-            RegionName.NONE : regionName;
+
         region = region ? region
             .set('startAddress', startAddress)
             .set('regionSize', regionSize)
             .set('colours', colours) :
             new Region({
-                name: regionName,
+                name: RegionName.NONE,
                 startAddress,
                 regionSize,
                 colours,
@@ -330,11 +326,33 @@ export function getRegionsFromOverlaps(overlaps, loadedContent, deviceInfo) {
         regions = regions.push(region);
     });
 
+    // Assume that the region on top of the SoftDevice is application.
+    // Assume also that the region on top of the MBR which is not SoftDevice is application.
+    const softDeviceRegion = regions.find(r => r.name === RegionName.SOFTDEVICE);
+    const pageSize = deviceInfo.pageSize;
+    if (softDeviceRegion) {
+        const softDeviceEnd = softDeviceRegion.startAddress + softDeviceRegion.regionSize;
+        let appRegion = regions.find(r =>
+            r.startAddress === Math.ceil((softDeviceEnd + 1) / pageSize) * pageSize);
+        if (appRegion) {
+            const appRegionIndex = regions.indexOf(appRegion);
+            appRegion = appRegion.set('name', RegionName.APPLICATION);
+            regions = regions.set(appRegionIndex, appRegion);
+        }
+    } else {
+        let appRegion = regions.find(r => r.startAddress === pageSize);
+        if (appRegion) {
+            const appRegionIndex = regions.indexOf(appRegion);
+            appRegion = appRegion.set('name', RegionName.APPLICATION);
+            regions = regions.set(appRegionIndex, appRegion);
+        }
+    }
+
     return regions;
 }
 
 /**
- * Given an instance of MemoryMap and DeviceDefinition,
+ * Given an instance of MemoryMap, content of loaded files and DeviceDefinition,
  * return the heuristically detected regions for loaded files.
  *
  * @param {Array}              memMaps      the memory map
@@ -351,18 +369,18 @@ export function getFileRegions(memMaps, loadedFiles, deviceInfo) {
 }
 
 /**
- * Given an instance of MemoryMap and DeviceDefinition,
- * return the heuristically detected regions for loaded files.
+ * Given an instance of MemoryMap, content of loaded device and DeviceDefinition,
+ * return the heuristically detected regions for loaded device.
  *
  * @param {Array}              memMaps      the memory map
- * @param {Hex}                loadedFiles  the loaded files
+ * @param {Hex}                loadedDevice  the loaded device
  * @param {DeviceDefinition}   deviceInfo   the device infomation
  *
  * @returns {List} the list of region
  */
-export function getTargetRegions(memMaps, loadedFiles, deviceInfo) {
+export function getTargetRegions(memMaps, loadedDevice, deviceInfo) {
     const overlaps = MemoryMap.overlapMemoryMaps(memMaps);
-    const regions = getRegionsFromOverlaps(overlaps, loadedFiles, deviceInfo);
+    const regions = getRegionsFromOverlaps(overlaps, loadedDevice, deviceInfo);
 
     return regions;
 }

--- a/lib/util/regions.js
+++ b/lib/util/regions.js
@@ -289,11 +289,9 @@ export function getMemoryRegions(memMap, deviceInfo) {
  *
  * @returns {List} the list of region
  */
-export function getFileRegions(memMaps, loadedFiles, deviceInfo) {
-    const overlaps = MemoryMap.overlapMemoryMaps(memMaps);
+export function getRegionsFromOverlaps(overlaps, loadedContent, deviceInfo) {
     const memMap = MemoryMap.flattenOverlaps(overlaps);
     const memRegions = getMemoryRegions(memMap, deviceInfo);
-
     let regions = new List();
     let region;
     overlaps.forEach((overlap, startAddress) => {
@@ -304,7 +302,7 @@ export function getFileRegions(memMaps, loadedFiles, deviceInfo) {
         overlap.forEach(([fileName, bytes]) => {
             regionSize = bytes.length;
             fileNames.push(fileName);
-            colours.push(loadedFiles[fileName].colour);
+            colours.push(loadedContent[fileName].colour);
         });
 
 
@@ -331,6 +329,40 @@ export function getFileRegions(memMaps, loadedFiles, deviceInfo) {
 
         regions = regions.push(region);
     });
+
+    return regions;
+}
+
+/**
+ * Given an instance of MemoryMap and DeviceDefinition,
+ * return the heuristically detected regions for loaded files.
+ *
+ * @param {Array}              memMaps      the memory map
+ * @param {Hex}                loadedFiles  the loaded files
+ * @param {DeviceDefinition}   deviceInfo   the device infomation
+ *
+ * @returns {List} the list of region
+ */
+export function getFileRegions(memMaps, loadedFiles, deviceInfo) {
+    const overlaps = MemoryMap.overlapMemoryMaps(memMaps);
+    const regions = getRegionsFromOverlaps(overlaps, loadedFiles, deviceInfo);
+
+    return regions;
+}
+
+/**
+ * Given an instance of MemoryMap and DeviceDefinition,
+ * return the heuristically detected regions for loaded files.
+ *
+ * @param {Array}              memMaps      the memory map
+ * @param {Hex}                loadedFiles  the loaded files
+ * @param {DeviceDefinition}   deviceInfo   the device infomation
+ *
+ * @returns {List} the list of region
+ */
+export function getTargetRegions(memMaps, loadedFiles, deviceInfo) {
+    const overlaps = MemoryMap.overlapMemoryMaps(memMaps);
+    const regions = getRegionsFromOverlaps(overlaps, loadedFiles, deviceInfo);
 
     return regions;
 }


### PR DESCRIPTION
1. The cause of the problem is that the real memory block shows softdevice starting at 0x1000 while the sofdevice magic number shows softdevice starting at 0x4000. Modifying the logic of detecting softdevice solve the issue.
2. According to applications, we consider that if the area is not starting from 0x0, is not a softdevice, is not a bootloader, then it is probably application. However, in this specific case, there are some extra contents than the original hex file as showing in the pic. I guess these are not applications, so I remove the label for them. The case is writing nRF5_SDK_15.0.0_a53641a\examples\ble_peripheral\ble_app_hrs\hex\ble_app_hrs_pca10056_s140.hex) into a 52840 devkit.
3. We need to figure out what those contents are later.

WIP: Optimze the way detecting application area.