### PR TITLE
Fix/erase and write

### DIFF
--- a/lib/actions/jlinkTargetActions.js
+++ b/lib/actions/jlinkTargetActions.js
@@ -94,7 +94,7 @@ function getDeviceInfo(serialNumber) {
 }
 
 // Get device memory map by calling nrfjprog and reading the entire non-volatile memory
-function getDeviceMemMap(serialNumber, devInfo) {
+function getDeviceMemMap(serialNumber, devInfo, fullRead = true) {
     return new Promise((resolve, reject) => {
         nrfjprog.open(serialNumber, openError => {
             if (openError) {
@@ -103,19 +103,27 @@ function getDeviceMemMap(serialNumber, devInfo) {
             logger.info('Reading device non-volatile memory. This may take a few seconds.');
             nrfjprog.read(
                 serialNumber,
-                devInfo.codeAddress,
-                devInfo.codeSize,
-                (err1, flashBytes) => {
-                    if (err1) {
-                        return reject(err1);
+                devInfo.uicrAddress,
+                devInfo.infoPageSize,
+                (readError, uicrBytes) => {
+                    if (readError) {
+                        return reject(readError);
                     }
+                    if (!fullRead) {
+                        logger.info('Quick read...');
+                        return resolve(new MemoryMap([[
+                            devInfo.uicrAddress,
+                            new Uint8Array(uicrBytes),
+                        ]]));
+                    }
+                    logger.info('Full read...');
                     nrfjprog.read(
                         serialNumber,
-                        devInfo.uicrAddress,
-                        devInfo.infoPageSize,
-                        (readError, uicrBytes) => {
-                            if (readError) {
-                                return reject(readError);
+                        devInfo.codeAddress,
+                        devInfo.codeSize,
+                        (err1, flashBytes) => {
+                            if (err1) {
+                                return reject(err1);
                             }
                             const memMap = MemoryMap.fromPaddedUint8Array(
                                 new Uint8Array(flashBytes), 0xFF, 256,
@@ -212,7 +220,7 @@ export function updateTargetRegions(regionsInput, memMap, deviceInfo) {
 
 // Display some information about a devkit. Called on a devkit connection.
 // This also triggers reading the whole memory contents of the device.
-export function loadDeviceInfo(serialNumberInput, refresh = false) {
+export function loadDeviceInfo(serialNumberInput, fullRead = false, eraseAndWrite = false) {
     return async (dispatch, getState) => {
         dispatch(targetActions.targetWarningKnownAction());
         dispatch(targetActions.targetTypeKnownAction(devices.CommunicationType.JLINK, true));
@@ -232,15 +240,16 @@ export function loadDeviceInfo(serialNumberInput, refresh = false) {
 
         let memMap = new MemoryMap();
         let isMemLoaded = false;
-        if (refresh || getState().app.settings.autoRead) {
-            try {
-                memMap = await getDeviceMemMap(serialNumber, info);
-                isMemLoaded = true;
-            } catch (error) {
-                logger.debug(`getDeviceMemMap: ${error.message}`);
-                return;
-            }
+
+        const readAll = !eraseAndWrite && (fullRead || getState().app.settings.autoRead);
+        try {
+            memMap = await getDeviceMemMap(serialNumber, info, readAll);
+            isMemLoaded = readAll;
+        } catch (error) {
+            logger.debug(`getDeviceMemMap: ${error.message}`);
+            return;
         }
+
         const regions = getMemoryRegions(memMap, deviceInfo);
         dispatch(targetActions.targetContentsKnownAction(memMap, isMemLoaded));
         dispatch(updateTargetRegions(regions, memMap, deviceInfo));
@@ -250,9 +259,9 @@ export function loadDeviceInfo(serialNumberInput, refresh = false) {
 
 // Reload device info
 export function refreshTargetContents() {
-    return (dispatch, getState) => {
+    return async (dispatch, getState) => {
         const serialNumber = parseInt(getState().app.target.serialNumber, 10);
-        dispatch(loadDeviceInfo(serialNumber, true));
+        await dispatch(loadDeviceInfo(serialNumber, true));
     };
 }
 
@@ -264,20 +273,20 @@ function writeHex(serialNumber, hexString) {
             chip_erase_mode: nrfjprog.ERASE_PAGES,
         }, progress => {
             logger.info(progress.process);
-        }, async err => {
+        }, err => {
             if (err) {
                 err.log.split('\n').forEach(line => logger.error(line));
                 return;
             }
             logger.info('Write procedure finished');
-            await dispatch(loadDeviceInfo(serialNumber));
-            dispatch(targetActions.writeProgressFinishedAction());
+            dispatch(loadDeviceInfo(serialNumber))
+                .then(() => dispatch(targetActions.writeProgressFinishedAction()));
         });
     };
 }
 
 // Calls nrfprog.recover().
-export function recover() {
+export function recover(eraseAndWrite = false) {
     return (dispatch, getState) => new Promise((resolve, reject) => {
         const appState = getState().app;
         const serialNumber = parseInt(appState.target.serialNumber, 10);
@@ -289,19 +298,18 @@ export function recover() {
             return;
         }
 
-
         nrfjprog.recover(serialNumber, progress => {
             logger.info(progress.process);
-        }, async err => {
+        }, err => {
             if (err) {
                 err.log.split('\n').forEach(logger.error);
                 reject();
                 return;
             }
             logger.info('Recovery procedure finished');
-            await dispatch(loadDeviceInfo(serialNumber));
-            dispatch(targetActions.writeProgressFinishedAction());
-            resolve();
+            dispatch(loadDeviceInfo(serialNumber, false, eraseAndWrite))
+                .then(() => dispatch(targetActions.writeProgressFinishedAction()))
+                .then(() => resolve());
         });
     });
 }
@@ -309,27 +317,28 @@ export function recover() {
 // Does some sanity checks, joins the loaded .hex files, flattens overlaps,
 // paginates the result to fit flash pages, and calls writeHex()
 export function write() {
-    return (dispatch, getState) => {
+    return async (dispatch, getState) => {
+        logger.info('Writing procedure starts');
         const appState = getState().app;
         const serialNumber = parseInt(appState.target.serialNumber, 10);
         const { pageSize, uicrBaseAddr, uicrSize } = appState.target.deviceInfo;
 
         if (!serialNumber || !pageSize) {
             logger.error('Select a device before writing');
-            return;
+            return undefined;
         }
 
         // Sanity check. Should never happen, as any write operations should be already
         // disabled in the UI.
         if (!canWrite(appState.target.memMap, appState.file.memMaps)) {
             logger.error('Can not write in the current state. Try erasing all non-volatile memory in the target.');
-            return;
+            return undefined;
         }
 
         // FIXME: Check if the target's UICR is blank. If not, slice the flattened
         // hex files so that the code doesn't try to overwrite UICR.
         // This is part of the «UICR can only be written to after an "erase all"» logic
-        checkUpToDateFiles(dispatch, getState).then(() => {
+        return checkUpToDateFiles(dispatch, getState).then(() => {
             let pages = MemoryMap.flattenOverlaps(
                 MemoryMap.overlapMemoryMaps(appState.file.memMaps),
             ).paginate(pageSize);
@@ -354,6 +363,6 @@ export function write() {
 
 // Erase all on device and write file to it.
 export function recoverAndWrite() {
-    return dispatch => dispatch(recover())
+    return dispatch => dispatch(recover(true))
         .then(() => dispatch(write()));
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Nordic Semiconductor ASA",
   "license": "SEE LICENSE IN LICENSE",
   "engines": {
-    "nrfconnect": "^2.4.0"
+    "nrfconnect": "^2.5.0"
   },
   "main": "dist/bundle.js",
   "files": [


### PR DESCRIPTION
For being able to write to jlink target, uicr needs to be read first, so we cannot avoid reading between erase (recover) and write. But performing a full read is too heavy, so reading the device is rearranged, uicr is read first and the rest is optional, depending on when or how the function was called.
Cleaned up promise chains in jlink actions.

Required engine version is bumped due to usage of newly exposed functions in previous PR.