### PR TITLE
Fix drag-n-drop for loading HEX files

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -58,20 +58,10 @@ export default {
         },
     },
     onInit: dispatch => {
-        document.ondrop = event => {
-            event.preventDefault();
-        };
-
-        document.ondragover = document.ondrop;
-
         document.body.ondragover = event => {
-            const dragOverEvent = event;
-            if (!dragOverEvent.dataTransfer.files.length) {
-                dragOverEvent.dataTransfer.dropEffect = 'none';
-                dragOverEvent.dataTransfer.effectAllowed = 'none';
-            } else {
-                dragOverEvent.dataTransfer.effectAllowed = 'uninitialized';
-            }
+            const ev = event;
+            ev.dataTransfer.dropEffect = 'copy';
+            ev.preventDefault();
         };
 
         document.body.ondrop = event => {


### PR DESCRIPTION
For the `dragOver` event `dataTransfer.files` is still empty, there's no need for that check, files will be check when they are about to be loaded.