### PR TITLE
Fix module import bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,13 +37,11 @@
     "babel-loader": "^7.1.2",
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "immutable": "^3.8.2",
-    "nrf-device-setup": "^0.2.9",
     "nrf-intel-hex": "^1.2.0",
     "pc-nrf-dfu-js": "^0.2.7",
     "pc-nrfconnect-devdep": "https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#semver:^1.3.0",
     "protobufjs": "^6.8.4",
-    "unclutter1d": "^0.2.0",
-    "usb": "1.3.1"
+    "unclutter1d": "^0.2.0"
   },
   "dependencies": {
     "electron-store": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "immutable": "^3.8.2",
     "nrf-intel-hex": "^1.2.0",
     "pc-nrf-dfu-js": "^0.2.7",
-    "pc-nrfconnect-devdep": "https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#semver:^1.3.0",
+    "pc-nrfconnect-devdep": "https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#semver:^1.3.4",
     "protobufjs": "^6.8.4",
     "unclutter1d": "^0.2.0"
   },


### PR DESCRIPTION
This PR is due to including nrf-usb and nrf-device-setup into pc-nrfconnect-core so that apps dont need to have duplicated dependencies.