### PR TITLE
Keep file warnings when removing target warnigns

### DIFF
--- a/lib/actions/usbsdfuTargetActions.js
+++ b/lib/actions/usbsdfuTargetActions.js
@@ -482,7 +482,7 @@ export function write() {
         logger.info('Performing DFU. This may take a few seconds');
         dispatch(targetActions.writingStartAction());
 
-        dispatch(warningActions.allWarningRemoveAction());
+        dispatch(warningActions.targetWarningRemoveAction());
         dispatch(createDfuImages());
 
         const fileRegions = getState().app.file.regions;


### PR DESCRIPTION
This PR is due to separating target warnings and file warnings.