### PR TITLE
Fix load mru files state

### DIFF
--- a/lib/actions/fileActions.js
+++ b/lib/actions/fileActions.js
@@ -292,6 +292,13 @@ export function closeFiles() {
     };
 }
 
+export function loadMruFiles() {
+    return dispatch => {
+        const files = persistentStore.get('mruFiles', []);
+        dispatch(mruFilesLoadSuccessAction(files));
+    };
+}
+
 function removeMruFile(filename) {
     const files = persistentStore.get('mruFiles', []);
     persistentStore.set('mruFiles', files.filter(file => file !== filename));
@@ -388,13 +395,7 @@ export function openFileDialog() {
 export function openFile(filename) {
     return dispatch => {
         dispatch(parseOneFile(filename));
-    };
-}
-
-export function loadMruFiles() {
-    return dispatch => {
-        const files = persistentStore.get('mruFiles', []);
-        dispatch(mruFilesLoadSuccessAction(files));
+        dispatch(loadMruFiles());
     };
 }
 


### PR DESCRIPTION
This PR is due to fixing incorrect state for Erase and write button. Drag and drop does not update MRU files state, so that the Erase & write button is disabled incorrectly.