### PR TITLE
Fix/scroll and read

### DIFF
--- a/lib/actions/jlinkTargetActions.js
+++ b/lib/actions/jlinkTargetActions.js
@@ -341,7 +341,7 @@ export function write() {
 
         const appState = getState().app;
         const serialNumber = parseInt(appState.target.serialNumber, 10);
-        const { pageSize, uicrBaseAddr, uicrSize } = appState.target.deviceInfo;
+        const { pageSize, uicrBaseAddr } = appState.target.deviceInfo;
 
         if (!serialNumber || !pageSize) {
             logger.error('Select a device before writing');

--- a/lib/components/ControlPanel.jsx
+++ b/lib/components/ControlPanel.jsx
@@ -64,7 +64,6 @@ const ControlPanel = ({
     onToggleFileList,
     mruFiles,
     fileRegionSize,
-    refreshEnabled,
     autoRead,
     toggleAutoRead,
     performJLinkRead,
@@ -153,7 +152,7 @@ const ControlPanel = ({
                     <Button
                         key="performJLinkRead"
                         onClick={performJLinkRead}
-                        disabled={!targetIsReady || !refreshEnabled}
+                        disabled={!targetIsReady || !isJLink}
                     >
                         <span className="mdi mdi-refresh" />Read
                     </Button>
@@ -194,7 +193,6 @@ ControlPanel.propTypes = {
     openFileDialog: PropTypes.func.isRequired,
     mruFiles: PropTypes.arrayOf(PropTypes.string).isRequired,
     fileRegionSize: PropTypes.number.isRequired,
-    refreshEnabled: PropTypes.bool.isRequired,
     autoRead: PropTypes.bool.isRequired,
     toggleAutoRead: PropTypes.func.isRequired,
     performJLinkRead: PropTypes.func.isRequired,

--- a/lib/containers/controlPanel.js
+++ b/lib/containers/controlPanel.js
@@ -56,11 +56,6 @@ export default connect(
         targetIsReady: !state.app.target.isLoading
             && !state.app.target.isWriting
             && !state.app.target.isErasing,
-        refreshEnabled: state.app.target.targetType === CommunicationType.JLINK
-            && !state.app.target.isMemLoaded
-            && !state.app.target.isLoading
-            && !state.app.target.isWriting
-            && !state.app.target.isErasing,
         isJLink: (state.app.target.targetType === CommunicationType.JLINK),
         isUsbSerial: (state.app.target.targetType === CommunicationType.USBSDFU),
         isModem: state.app.target.isModem,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-programmer",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Program a Nordic SoC with HEX files from nRF Connect",
   "displayName": "Programmer",
   "repository": {

--- a/resources/css/index.scss
+++ b/resources/css/index.scss
@@ -42,10 +42,6 @@
     padding: 10px 15px;
 }
 
-.core-main-layout > div:nth-child(2) {
-    overflow-y: visible;
-}
-
 .app-main-view {
     display: flex;
     height: 100%;


### PR DESCRIPTION
This PR fixes main layout scrolling issue by relying on core's updated style rule.
Device action to read jlink contents is not disabled any more after the first read.