### PR TITLE
Fix programming nRF51 device with UICR

### DIFF
--- a/lib/actions/jlinkTargetActions.js
+++ b/lib/actions/jlinkTargetActions.js
@@ -399,7 +399,7 @@ export const writeOneCore = core => async (dispatch, getState) => {
     logger.info(`Writing procedure starts for core${core.coreNumber}`);
     dispatch(targetActions.writingStartAction());
     const {
-        target: { serialNumber },
+        target: { serialNumber, deviceInfo: { family } },
         file: { memMaps },
     } = getState().app;
     const { pageSize, uicrBaseAddr } = core;
@@ -432,8 +432,11 @@ export const writeOneCore = core => async (dispatch, getState) => {
     // In case the hex files include UICR, we need to erase that from the
     // device and avoid resetting, that will be done by pc-nrfjprog-js
     if ([...programRegions.keys()].find(addr => addr >= uicrBaseAddr) !== undefined) {
+        const chipEraseMode = family === 'nRF51'
+            ? nrfjprog.ERASE_PAGES
+            : nrfjprog.ERASE_PAGES_INCLUDING_UICR;
         await writeHex(serialNumberWithCore, programRegions.asHexString(64), {
-            chip_erase_mode: nrfjprog.ERASE_PAGES_INCLUDING_UICR,
+            chip_erase_mode: chipEraseMode,
             reset: false,
         });
     } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-programmer",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Program a Nordic SoC with HEX files from nRF Connect",
   "displayName": "Programmer",
   "repository": {


### PR DESCRIPTION
This PR fixes #155 where nrfjprog does not support certain erase mode on 51 family devices.