### PR TITLE
Changelog as release notes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,32 @@
+## Version 1.3.1
+## Bugfixes
+- Fix programming nRF51 devices with UICR #156
+
+## Version 1.3.0
+### New features
+* Supported nRF53 series
+* Supported nRF52833
+* Supported MCUboot DFU
+
+## Version 1.2.3
+### Bugfixes
+- Fix cropped most recently used files dropdown #142
+
+## Version 1.2.2
+### Bugfixes
+- Fix for UICR handling that caused double reset failure #133
+
+## Version 1.2.0
+### Updates
+- Updated to React Bootstrap 4
+
+## Version 1.1.0
+### New features
+- Added modem DFU support
+- Added list of devices and details of current device to system report
+### Updates
+- Updated algorithm of detecting application regions
+- Added nRF52810 to supported devices
+- Added SdReq for SoftDevice S140 v6.1.0
+### Bugfixes
+- Fixed logic of reloading files

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "immutable": "^3.8.2",
     "nrf-intel-hex": "^1.2.0",
     "pc-nrf-dfu-js": "^0.2.10",
-    "pc-nrfconnect-devdep": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#semver:^3.1.0",
+    "pc-nrfconnect-devdep": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#semver:3.3.0",
     "protobufjs": "^6.8.4"
   },
   "dependencies": {


### PR DESCRIPTION
This is part of [NCP-2820](https://projecttools.nordicsemi.no/jira/browse/NCP-2820). The whole concept is described there.

This changes two things:
- It adds a `Changelog.md` which contains all entries that were previously in the GitHub releases.
- It references devdep 3.3 so that future releases of this app will also upload the `Changelog.md` to developer.nordicsemi.com.

Because this changes depends on the release of devdep 3.3, this PR is created as a draft PR and  will be marked as being ready later when NordicSemiconductor/pc-nrfconnect-devdep#26 is merged and devdep 3.3 is released.