### PR TITLE
Harden against new serialport

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -47,6 +47,7 @@ import ControlPanel from './lib/containers/controlPanel';
 import appReducer from './lib/reducers';
 import { hexToKiB, hexpad2 } from './lib/util/hexpad';
 import logJprogVersion from './lib/util/logJprogVersion';
+import portPath from './lib/util/portPath';
 
 let detectedDevices = [];
 let currentDeviceInfo;
@@ -135,7 +136,7 @@ export default {
         const report = [
             '- Connected devices:',
             ...detectedDevices.map(d => (
-                `    - ${d.serialport.comName}: ${d.serialNumber} ${d.boardVersion || ''}`
+                `    - ${portPath(d.serialport)}: ${d.serialNumber} ${d.boardVersion || ''}`
             )),
             '',
         ];

--- a/lib/actions/mcubootTargetActions.js
+++ b/lib/actions/mcubootTargetActions.js
@@ -157,7 +157,7 @@ export const toggleMcuboot = () => (dispatch, getState) => {
         dispatch(portKnownAction(null));
     } else {
         dispatch(mcubootKnownAction(true));
-        dispatch(portKnownAction(port.comName));
+        dispatch(portKnownAction(port));
     }
 
     dispatch(targetActions.updateTargetWritable());

--- a/lib/actions/mcubootTargetActions.js
+++ b/lib/actions/mcubootTargetActions.js
@@ -40,6 +40,7 @@ import { logger } from 'nrfconnect/core';
 import nrfjprog from 'pc-nrfjprog-js';
 
 import { CommunicationType } from '../util/devices';
+import portPath from '../util/portPath';
 import * as targetActions from './targetActions';
 import * as warningActions from './warningActions';
 import { modemKnownAction } from './modemTargetActions';
@@ -110,7 +111,7 @@ export const pickSerialPort = serialports => {
         case 'lin':
             return serialports.find(s => (/-if00$/.test(s.pnpId)));
         case 'dar':
-            return serialports.find(s => (/1$/.test(s.comName)));
+            return serialports.find(s => (/1$/.test(portPath(s))));
         default:
     }
 
@@ -126,7 +127,7 @@ export const pickSerialPort2 = serialports => {
         case 'lin':
             return serialports.find(s => (/-if0[23]$/.test(s.pnpId)));
         case 'dar':
-            return serialports.find(s => (/[34]$/.test(s.comName)));
+            return serialports.find(s => (/[34]$/.test(portPath(s))));
         default:
     }
 
@@ -141,8 +142,8 @@ export const openDevice = selectedDevice => dispatch => {
     dispatch(mcubootKnownAction(true));
     dispatch(modemKnownAction(true));
     dispatch(portKnownAction(
-        pickSerialPort(serialports).comName,
-        pickSerialPort2(serialports).comName,
+        portPath(pickSerialPort(serialports)),
+        portPath(pickSerialPort2(serialports)),
     ));
     dispatch(targetActions.updateTargetWritable());
     dispatch(targetActions.loadingEndAction());

--- a/lib/actions/targetActions.js
+++ b/lib/actions/targetActions.js
@@ -48,6 +48,7 @@ import { refreshAllFiles } from './fileActions';
 import * as jlinkTargetActions from './jlinkTargetActions';
 import * as mcubootTargetActions from './mcubootTargetActions';
 import * as usbsdfuTargetActions from './usbsdfuTargetActions';
+import portPath from '../util/portPath';
 
 export const DFU_IMAGES_UPDATE = 'DFU_IMAGES_UPDATE';
 export const ERASING_END = 'ERASING_END';
@@ -90,10 +91,10 @@ export const targetWritableKnownAction = isWritable => ({
     isWritable,
 });
 
-export const targetPortChangedAction = (serialNumber, comName) => ({
+export const targetPortChangedAction = (serialNumber, path) => ({
     type: TARGET_PORT_CHANGED,
     serialNumber,
-    comName,
+    path,
 });
 
 export const dfuImagesUpdateAction = dfuImages => ({
@@ -130,7 +131,7 @@ export const openDevice = device => dispatch => {
 
     const { serialNumber, serialport } = device;
 
-    dispatch(targetPortChangedAction(serialNumber, serialport ? serialport.comName : null));
+    dispatch(targetPortChangedAction(serialNumber, serialport ? portPath(serialport) : null));
 
     if (device.traits.includes('jlink')) {
         dispatch(jlinkTargetActions.loadDeviceInfo(serialNumber));

--- a/lib/actions/usbsdfuTargetActions.js
+++ b/lib/actions/usbsdfuTargetActions.js
@@ -76,6 +76,7 @@ import * as fileActions from './fileActions';
 import * as targetActions from './targetActions';
 import * as userInputActions from './userInputActions';
 import * as warningActions from './warningActions';
+import portPath from '../util/portPath';
 
 const { InitPacket } = initPacket;
 const DfuImage = new Record({
@@ -85,8 +86,8 @@ const DfuImage = new Record({
 });
 
 // Get device versions by calling version command
-export const getDeviceVersions = async comName => {
-    const port = new SerialPort(comName, { baudRate: 115200, autoOpen: false });
+const getDeviceVersions = async path => {
+    const port = new SerialPort(path, { baudRate: 115200, autoOpen: false });
     return new Promise(async resolve => {
         const serialTransport = new DfuTransportSerial(port, 0);
         const protocolVersion = await serialTransport.getProtocolVersion();
@@ -123,13 +124,13 @@ export const getDeviceVersions = async comName => {
 
 // Display some information about a devkit. Called on a devkit connection.
 const loadDeviceInfo = selectedDevice => async dispatch => {
-    const { comName } = selectedDevice.serialport;
+    const path = portPath(selectedDevice.serialport);
     dispatch(warningActions.targetWarningRemoveAction());
     dispatch(targetActions.targetTypeKnownAction(CommunicationType.USBSDFU, false));
     logger.info('Using USB SDFU protocol to communicate with target');
 
     try {
-        const { hardwareVersion, firmwareVersions } = await getDeviceVersions(comName);
+        const { hardwareVersion, firmwareVersions } = await getDeviceVersions(path);
         const deviceInfoOrigin = getDeviceInfoByUSB(hardwareVersion);
         dispatch(targetActions.targetInfoKnownAction(deviceInfoOrigin));
 
@@ -213,7 +214,7 @@ export const openDevice = selectedDevice => dispatch => Promise.resolve(selected
                 return detachAndWaitFor(usbdev, interfaceNumber, selectedDevice.serialNumber)
                     .then(newDevice => {
                         dispatch(targetActions.targetPortChangedAction(
-                            newDevice.serialNumber, newDevice.serialport.comName,
+                            newDevice.serialNumber, portPath(newDevice.serialport),
                         ));
                         dispatch(startWatchingDevices());
                         return newDevice;

--- a/lib/reducers/targetReducer.js
+++ b/lib/reducers/targetReducer.js
@@ -80,7 +80,7 @@ export default function target(state = new InitialState(), action) {
         case targetActions.TARGET_PORT_CHANGED:
             return state
                 .set('serialNumber', action.serialNumber)
-                .set('port', action.comName);
+                .set('port', action.path);
 
         case targetActions.TARGET_CONTENTS_KNOWN:
             return state

--- a/lib/util/portPath.js
+++ b/lib/util/portPath.js
@@ -1,0 +1,38 @@
+/* Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Prefer to use the serialport 8 property or fall back to the serialport 7 property
+export default serialPort => serialPort.path || serialPort.comName;


### PR DESCRIPTION
Part of [NCP-2996](https://projecttools.nordicsemi.no/jira/browse/NCP-2996).

This enables the app to run with either serialport 7 (which had comName as a property) or serialport 8 (which moved to the property path and warns when still using comName).

In b4711d4dc554 I just removed the `.comName` at one place, because I am convinced that this was a bug before: Observing the app state I came to the conclusion, that `app.target.port` already contains a string representing the path/com name, so getting the property `comName` from that just always would be `undefined`.