### PR TITLE
Add USB PID of OpenThread devices

### DIFF
--- a/lib/util/devices.js
+++ b/lib/util/devices.js
@@ -141,7 +141,7 @@ export const VendorId = {
     NORDIC_SEMICONDUCTOR: 0x1915,
 };
 
-export const USBProductIds = [0x521f, 0xc00a];
+export const USBProductIds = [0x521f, 0xc00a, 0xcafe];
 
 export const McubootProductIds = [0x520f, 0x9100];
 


### PR DESCRIPTION
This PR adds to the list PID used in OpenThread samples which can have the trigger functionality compiled in as well.

Signed-off-by: Piotr Szkotak <piotr.szkotak@nordicsemi.no>