### PR TITLE
use comName to located the serialport

### DIFF
--- a/src/util/portPath.ts
+++ b/src/util/portPath.ts
@@ -14,4 +14,4 @@
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default (serialPort: any): string =>
-    serialPort ? serialPort.path || serialPort.comName : undefined;
+    serialPort ? serialPort.comName : undefined;


### PR DESCRIPTION
On Windows the .path attribute is mapped to a com port using a string,
to make it more readible it's preferable to use the .comName attribute.

On Linux the .path attribute is equal to the .comName attribute. Which
means it is favorable to use .comName to make it consistent with Windows.