### PR TITLE
Temporarily remove progress bar from modem dfu dialog

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## 2.0.1
+### Changed
+- Simplify modem DFU progress indicator temporarily
+
 ## 2.0.0 - 2021-11-01
 ### Added
 - Documentation section in `About` pane.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-programmer",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Program a Nordic SoC with HEX files from nRF Connect",
     "displayName": "Programmer",
     "repository": {

--- a/src/actions/modemTargetActions.ts
+++ b/src/actions/modemTargetActions.ts
@@ -69,6 +69,17 @@ export const programDfuModem =
                 progressJson: progress,
             }: nrfdl.Progress.CallbackParameters) => {
                 let updatedProgress = progress;
+                // temporary until new nRF Command Line Tools comes out which includes proper progress callbacks again
+                const skipProgressReport = true;
+                if (skipProgressReport) {
+                    updatedProgress = {
+                        ...progress,
+                        message: 'Uploading image. This might take some time.',
+                    };
+                    dispatch(modemProcessUpdate(updatedProgress));
+                    return;
+                }
+                // For now we will not get these progress callbacks, until this is fixed in nRF Command Line Tools
                 if (progress.operation === 'erase_image') {
                     updatedProgress = {
                         ...progress,

--- a/src/components/ModemUpdateDialogView.tsx
+++ b/src/components/ModemUpdateDialogView.tsx
@@ -53,6 +53,8 @@ const ModemUpdateDialogView = () => {
         pause();
     }
 
+    const temporarilySkippingProgressBar = true;
+
     return (
         <Modal show={isVisible} onHide={onCancel} backdrop="static">
             <Modal.Header>
@@ -74,7 +76,7 @@ const ModemUpdateDialogView = () => {
                         <b>Status</b>
                     </Form.Label>
                     <div>{progressMsg}</div>
-                    {isWriting && (
+                    {isWriting && !temporarilySkippingProgressBar && (
                         <ProgressBar
                             hidden={!isWriting}
                             animated


### PR DESCRIPTION
With latest version of `nrf-device-lib-js` / `nRF Command Line Tools` 10.15.1 we no longer get progress callbacks after the first stage. The resulting behavior is such that the progress bar is immediately filled, as we do get an initial progress callback for the firs t stage with `progressPercentage` 100, making the user believe the DFU is completed, when it will still take tens of seconds to complete. So to prevent this, we temporarily disable showing the progress bar, and instead write a message saying it will take some time, as shown in the picture below. When there is a new release of `nRF Command Line Tools` which returns these progress callbacks, we can improve this behavior.

![image](https://user-images.githubusercontent.com/72191781/143025482-f370d94f-c4b2-4a72-a8e6-22f554c9c402.png)

On success:

![image](https://user-images.githubusercontent.com/72191781/143026195-5d5cbe06-1a7c-4e02-b959-8056c27edf89.png)

How the behavior is before this PR (not that the DFU is not actually done at this point):
![image](https://user-images.githubusercontent.com/72191781/143026859-2537563f-ac8d-461a-8c15-8c1e6b1b1748.png)


