### PR TITLE
Set required engine version to 3.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "author": "Nordic Semiconductor ASA",
     "license": "SEE LICENSE IN LICENSE",
     "engines": {
-        "nrfconnect": "^3.8.0"
+        "nrfconnect": "^3.9.2"
     },
     "main": "dist/bundle.js",
     "files": [


### PR DESCRIPTION
We use `truncateMiddle` utility from `pc-nrfconnect-shared` which is
only available in Launcher version 3.9.2 and newer.