### PR TITLE
Update/reset functionality

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,15 +1,12 @@
-## 2.1.3 - unreleased
+## 2.1.2 - unreleased
 ### Added
 - Auto-reset setting which, if toggled, adds a device reset after read/write operations.
+- Instructions for updating the modem firmware.
 
 ### Fixed
 - Issue with programming nRF52 SoC on Thingy91.
 - Reset button is now disabled for USB devices as this operation is currently not supported.
 - Reset button now works for JLink devices.
-
-## 2.1.2 - 2022-01-12
-### Added
-- Instructions for updating the modem firmware.
 
 ## 2.1.1 - 2022-01-07
 ### Fixed

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-## 2.1.2 - unreleased
+## 2.2.0 - unreleased
 ### Added
 - Auto-reset setting which, if toggled, adds a device reset after read/write operations.
 - Instructions for updating the modem firmware.
@@ -7,6 +7,9 @@
 - Issue with programming nRF52 SoC on Thingy91.
 - Reset button is now disabled for USB devices as this operation is currently not supported.
 - Reset button now works for JLink devices.
+
+### Changed
+- Device is no longer by default reset after a write operation, if the user wants to reset the device after write, use the new `Auto reset` feature.
 
 ## 2.1.1 - 2022-01-07
 ### Fixed

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 ## 2.1.3 - unreleased
+### Added
+- Auto-reset setting which, if toggled, adds a device reset after read/write operations.
+
 ### Fixed
 - Issue with programming nRF52 SoC on Thingy91.
+- Reset button is now disabled for USB devices as this operation is currently not supported.
+- Reset button now works for JLink devices.
 
 ## 2.1.2 - 2022-01-12
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-programmer",
-    "version": "2.1.2",
+    "version": "2.2.0",
     "description": "Program a Nordic SoC with HEX files from nRF Connect",
     "displayName": "Programmer",
     "repository": {

--- a/resources/css/controlPanel.scss
+++ b/resources/css/controlPanel.scss
@@ -60,6 +60,19 @@ $labelHeight: 12px;
             color: rgba(0, 0, 0, 0.88);
         }
     }
+
+    .auto-reset-checkbox {
+        label {
+            margin-bottom: 0;
+            display: flex;
+            justify-content: space-between;
+            padding-right: 12px;
+
+            .mdi-alert {
+                color: orange;
+            }
+        }
+    }
 }
 
 .mru-popover {

--- a/resources/css/controlPanel.scss
+++ b/resources/css/controlPanel.scss
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
+@import '~pc-nrfconnect-shared/styles';
 $labelHeight: 12px;
 
 .control-panel {
@@ -69,7 +70,7 @@ $labelHeight: 12px;
             padding-right: 12px;
 
             .mdi-alert {
-                color: orange;
+                color: $gray-400;
             }
         }
     }

--- a/src/actions/jlinkTargetActions.ts
+++ b/src/actions/jlinkTargetActions.ts
@@ -19,6 +19,7 @@ import MemoryMap, { MemoryMaps } from 'nrf-intel-hex';
 import { getDeviceLibContext, logger, usageData } from 'pc-nrfconnect-shared';
 
 import { modemKnown } from '../reducers/modemReducer';
+import { getAutoReset } from '../reducers/settingsReducer';
 import {
     erasingEnd,
     erasingStart,
@@ -362,6 +363,9 @@ export const read =
 
         dispatch(updateTargetWritable());
         dispatch(loadingEnd());
+
+        const autoReset = getAutoReset(getState());
+        if (autoReset) dispatch(resetDevice());
     };
 
 /**
@@ -531,7 +535,8 @@ export const write =
             argsArray
         );
         dispatch(writingEnd());
-        await dispatch(resetDevice());
+        const autoReset = getAutoReset(getState());
+        if (autoReset) await dispatch(resetDevice());
         await dispatch(openDevice());
         dispatch(updateTargetWritable());
     };

--- a/src/actions/settingsActions.ts
+++ b/src/actions/settingsActions.ts
@@ -9,6 +9,7 @@ import Store from 'electron-store';
 import {
     settingsLoad,
     toggleAutoRead as toggleAutoReadAction,
+    toggleAutoReset as toggleAutoResetAction,
 } from '../reducers/settingsReducer';
 import { RootState, TDispatch } from '../reducers/types';
 
@@ -33,6 +34,18 @@ export function toggleAutoRead() {
         // otherwise the state would be the same as before toggling
         persistentStore.set('settings', {
             autoRead: getState().app.settings.autoRead,
+        });
+    };
+}
+
+export function toggleAutoReset() {
+    return (dispatch: TDispatch, getState: () => RootState) => {
+        dispatch(toggleAutoResetAction());
+
+        // Do not use async functions above，
+        // otherwise the state would be the same as before toggling
+        persistentStore.set('settings', {
+            autoReset: getState().app.settings.autoReset,
         });
     };
 }

--- a/src/actions/settingsActions.ts
+++ b/src/actions/settingsActions.ts
@@ -21,6 +21,9 @@ export function loadSettings() {
         if (!settings.autoRead) {
             settings.autoRead = false;
         }
+        if (!settings.autoReset) {
+            settings.autoReset = false;
+        }
         persistentStore.set('settings', settings);
         dispatch(settingsLoad(settings));
     };

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -189,7 +189,13 @@ const ControlPanel = () => {
         dispatch(jlinkTargetActions.recoverAndWrite());
     const performSaveAsFile = () => dispatch(jlinkTargetActions.saveAsFile());
     const performJLinkRead = () => dispatch(jlinkTargetActions.read());
-    const performReset = () => dispatch(usbsdfuTargetActions.resetDevice());
+    const performReset = () => {
+        if (isUsbSerial) {
+            dispatch(usbsdfuTargetActions.resetDevice());
+        } else {
+            dispatch(jlinkTargetActions.resetDevice());
+        }
+    };
     const performWrite = () => dispatch(targetActions.write());
 
     return (
@@ -252,7 +258,9 @@ const ControlPanel = () => {
                         <Button
                             key="performReset"
                             onClick={performReset}
-                            disabled={!isUsbSerial || !targetIsReady}
+                            disabled={
+                                !(isUsbSerial || isJLink) || !targetIsReady
+                            }
                         >
                             <span className="mdi mdi-record" />
                             Reset

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -24,6 +24,7 @@ import * as targetActions from '../actions/targetActions';
 import * as usbsdfuTargetActions from '../actions/usbsdfuTargetActions';
 import { getFileRegions, getMruFiles } from '../reducers/fileReducer';
 import { getIsMcuboot } from '../reducers/mcubootReducer';
+import { getIsModem } from '../reducers/modemReducer';
 import { getAutoRead, getAutoReset } from '../reducers/settingsReducer';
 import {
     getDeviceInfo,
@@ -179,6 +180,7 @@ const ControlPanel = () => {
     const isUsbSerial =
         useSelector(getTargetType) === CommunicationType.USBSDFU;
     const isMcuboot = useSelector(getIsMcuboot);
+    const isModem = useSelector(getIsModem);
 
     const dispatch = useDispatch();
     const closeFiles = () => dispatch(fileActions.closeFiles());
@@ -299,11 +301,23 @@ const ControlPanel = () => {
                         <Form.Check
                             type="checkbox"
                             id="auto-reset-checkbox"
-                            className="last-checkbox"
-                            onChange={() => toggleAutoReset()}
-                            checked={autoReset}
-                            label="Auto reset"
-                        />
+                            className="last-checkbox auto-reset-checkbox"
+                        >
+                            <Form.Check.Input
+                                type="checkbox"
+                                checked={autoReset}
+                                onChange={() => toggleAutoReset()}
+                            />
+                            <Form.Label>
+                                <span>Auto reset</span>
+                                {isModem && autoReset && (
+                                    <span
+                                        title="Resetting modem too many times might cause it to lock up, use this setting with care for devices with modem."
+                                        className="mdi mdi-alert"
+                                    />
+                                )}
+                            </Form.Label>
+                        </Form.Check>
                         <Form.Check
                             type="checkbox"
                             id="toggle-mcuboot-checkbox"

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -307,10 +307,11 @@ const ControlPanel = () => {
                                 type="checkbox"
                                 checked={autoReset}
                                 onChange={() => toggleAutoReset()}
+                                title="Reset device after read/write operations"
                             />
                             <Form.Label>
                                 <span>Auto reset</span>
-                                {isModem && autoReset && (
+                                {isJLink && isModem && autoReset && (
                                     <span
                                         title="Resetting modem too many times might cause it to lock up, use this setting with care for devices with modem."
                                         className="mdi mdi-alert"

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -24,7 +24,7 @@ import * as targetActions from '../actions/targetActions';
 import * as usbsdfuTargetActions from '../actions/usbsdfuTargetActions';
 import { getFileRegions, getMruFiles } from '../reducers/fileReducer';
 import { getIsMcuboot } from '../reducers/mcubootReducer';
-import { getAutoRead } from '../reducers/settingsReducer';
+import { getAutoRead, getAutoReset } from '../reducers/settingsReducer';
 import {
     getDeviceInfo,
     getIsMemLoaded,
@@ -167,6 +167,7 @@ const ControlPanel = () => {
     const fileRegionSize = useSelector(getFileRegions)?.length;
     const mruFiles = useSelector(getMruFiles);
     const autoRead = useSelector(getAutoRead);
+    const autoReset = useSelector(getAutoReset);
     const targetIsWritable = useSelector(getIsWritable);
     const targetIsRecoverable = useSelector(getIsRecoverable);
     const targetIsMemLoaded = useSelector(getIsMemLoaded);
@@ -183,6 +184,7 @@ const ControlPanel = () => {
     const closeFiles = () => dispatch(fileActions.closeFiles());
     const refreshAllFiles = () => dispatch(fileActions.refreshAllFiles());
     const toggleAutoRead = () => dispatch(settingsActions.toggleAutoRead());
+    const toggleAutoReset = () => dispatch(settingsActions.toggleAutoReset());
     const toggleMcuboot = () => dispatch(mcubootTargetActions.toggleMcuboot());
     const performRecover = () => dispatch(jlinkTargetActions.recover());
     const performRecoverAndWrite = () =>
@@ -295,6 +297,14 @@ const ControlPanel = () => {
                             onChange={() => toggleAutoRead()}
                             checked={autoRead}
                             label="Auto read memory"
+                        />
+                        <Form.Check
+                            type="checkbox"
+                            id="auto-reset-checkbox"
+                            className="last-checkbox"
+                            onChange={() => toggleAutoReset()}
+                            checked={autoReset}
+                            label="Auto reset"
                         />
                         <Form.Check
                             type="checkbox"

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -260,9 +260,7 @@ const ControlPanel = () => {
                         <Button
                             key="performReset"
                             onClick={performReset}
-                            disabled={
-                                !(isUsbSerial || isJLink) || !targetIsReady
-                            }
+                            disabled={!isJLink || !targetIsReady}
                         >
                             <span className="mdi mdi-record" />
                             Reset

--- a/src/reducers/settingsReducer.ts
+++ b/src/reducers/settingsReducer.ts
@@ -10,10 +10,12 @@ import { RootState } from './types';
 
 export interface SettingsState {
     autoRead: boolean;
+    autoReset: boolean;
 }
 
 const initialState: SettingsState = {
     autoRead: false,
+    autoReset: false,
 };
 
 const settingsSlice = createSlice({
@@ -22,17 +24,22 @@ const settingsSlice = createSlice({
     reducers: {
         settingsLoad(state, action: PayloadAction<SettingsState>) {
             state.autoRead = action.payload.autoRead;
+            state.autoReset = action.payload.autoReset;
         },
         toggleAutoRead(state) {
             state.autoRead = !state.autoRead;
+        },
+        toggleAutoReset(state) {
+            state.autoReset = !state.autoReset;
         },
     },
 });
 
 export default settingsSlice.reducer;
 
-const { settingsLoad, toggleAutoRead } = settingsSlice.actions;
+const { settingsLoad, toggleAutoRead, toggleAutoReset } = settingsSlice.actions;
+
+export { settingsLoad, toggleAutoRead, toggleAutoReset };
 
 export const getAutoRead = (state: RootState) => state.app.settings.autoRead;
-
-export { settingsLoad, toggleAutoRead };
+export const getAutoReset = (state: RootState) => state.app.settings.autoReset;


### PR DESCRIPTION
This PR implements a fix for the Auto read issue described [here](https://trello.com/c/0ptSmvWH/393-auto-read-issue-in-programmer).

There are multiple smaller parts worth considering seperately here:
- f5d8bec:  Enable Reset button for JLink devices.
- 9bd7aa1: Disable Reset button for USB devices as this is currently not supported by `nrf-device-lib`.
- The rest of the commits are all related to adding `Auto reset`  functionality, which if checked, will ensure that a reset is done after read/write operations, to make sure that the device ends up in the application mode after reading/writing (i.e. how the Programmer worked before we changed to `device-lib` in the backend).

There is also an issue that resetting the modem too many times (I don't know the number) in a given time interval will lock it, so we add a warning sign with a tooltip on hover if the device selected has a modem.

![image](https://user-images.githubusercontent.com/72191781/149151571-95b3a88a-eb72-49e5-b98a-26f8060df3be.png)

