### PR TITLE
Fix calls to watch devices

### DIFF
--- a/src/actions/usbsdfuTargetActions.ts
+++ b/src/actions/usbsdfuTargetActions.ts
@@ -25,8 +25,6 @@ import {
     HashType,
     logger,
     sdfuOperations,
-    startWatchingDevices,
-    stopWatchingDevices,
     usageData,
     waitForDevice,
 } from 'pc-nrfconnect-shared';
@@ -640,7 +638,6 @@ export const write =
         logger.info('Performing DFU. This may take a few seconds');
         dispatch(writingStart());
 
-        stopWatchingDevices();
         try {
             const state = getState();
             const device =
@@ -648,7 +645,6 @@ export const write =
             if (!device) throw Error(`Failed to write due to device not found`);
             await operateDFU(device.id, images);
             dispatch(writingEnd());
-            startWatchingDevices();
             const reconnectedDevice = await waitForDevice(device.serialNumber);
             dispatch(targetActions.openDevice(reconnectedDevice));
         } catch (error) {


### PR DESCRIPTION
Calling `startWatchingDevices` was wrong in two ways:
- It is a thunk, so the result needs to be dispatched to do anything.
  In the current for it was just a no-op.
- It needs two parameters: the device listing configuration and a
  callback to deselect the current device. But at least the latter is
  not trivial to provide by an app.

So, since the call effectively did nothing, we seemingly can also remove
it. But it is strange to to then leave the call to `stopWatchingDevices`
in there. I also removed it and could not detect any problems that
come out of this change.