### PR TITLE
Fix/reset nrf53

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,10 @@
-## Unreleased
+## 2.2.1
 ### Changed
 - Use shared code for persisting local settings in app.
+- Detect cores on nRF53 with readback protection.
+
+### Fixed
+- Remove readback protection on nRF53
 
 ## 2.2.0 - 2022-01-13
 ### Added

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,8 @@
 - Detect cores on nRF53 with readback protection.
 
 ### Fixed
-- Remove readback protection on nRF53
+- Remove readback protection on nRF53.
+- Dropping several hex files.
 
 ## 2.2.0 - 2022-01-13
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-programmer",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "author": "Nordic Semiconductor ASA",
     "license": "SEE LICENSE IN LICENSE",
     "engines": {
-        "nrfconnect": "^3.9.2"
+        "nrfconnect": "^3.10.0"
     },
     "main": "dist/bundle.js",
     "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-programmer",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "description": "Program a Nordic SoC with HEX files from nRF Connect",
     "displayName": "Programmer",
     "repository": {

--- a/src/actions/fileActions.ts
+++ b/src/actions/fileActions.ts
@@ -28,7 +28,7 @@ import { getMruFiles, setMruFiles } from '../store';
 import {
     CoreDefinition,
     coreFriendlyName,
-    deviceDefinition,
+    defaultDeviceDefinition,
     getDeviceDefinition,
 } from '../util/devices';
 import {
@@ -77,7 +77,7 @@ const updateCoreInfo =
         ) {
             dispatch(
                 targetInfoKnown({
-                    ...deviceDefinition,
+                    ...defaultDeviceDefinition,
                     cores: [
                         {
                             ...cores[0],
@@ -102,7 +102,7 @@ const updateCoreInfo =
             const lastEndAddress = lastStartAddress + lastOverlap[0][1]?.length;
             dispatch(
                 targetInfoKnown({
-                    ...deviceDefinition,
+                    ...defaultDeviceDefinition,
                     cores: [
                         {
                             ...cores[0],
@@ -309,7 +309,7 @@ export const closeFiles =
 
         // Initialize the state of deviceInfo if no device is selected
         if (!getState().app.target.deviceInfo?.type) {
-            dispatch(targetInfoKnown(deviceDefinition));
+            dispatch(targetInfoKnown(defaultDeviceDefinition));
         }
         dispatch(updateTargetWritable());
     };

--- a/src/actions/fileActions.ts
+++ b/src/actions/fileActions.ts
@@ -27,6 +27,7 @@ import { fileWarningAdd, fileWarningRemove } from '../reducers/warningReducer';
 import { getMruFiles, setMruFiles } from '../store';
 import {
     CoreDefinition,
+    coreFriendlyName,
     deviceDefinition,
     getDeviceDefinition,
 } from '../util/devices';
@@ -249,9 +250,13 @@ export const updateFileRegions =
         const cores = target.deviceInfo?.cores as CoreDefinition[];
 
         let regions: Region[] = [];
-        cores.forEach((c: CoreDefinition) => {
-            logger.info(`Update files regions according to ${c.name} core`);
-            regions = [...regions, ...getFileRegions(file.memMaps, c)];
+        cores.forEach((core: CoreDefinition) => {
+            logger.info(
+                `Update files regions according to ${coreFriendlyName(
+                    core.name
+                )} core`
+            );
+            regions = [...regions, ...getFileRegions(file.memMaps, core)];
         });
 
         // Show file warning if file region is out of core memory.

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -45,17 +45,19 @@ const useRegisterDragEvents = () => {
             event.preventDefault();
         };
 
-        const onDrop = (event: DragEvent) => {
+        const onDrop = async (event: DragEvent) => {
             if (!event.dataTransfer) return;
 
-            Array.from(event.dataTransfer.files).forEach(file => {
-                dispatch(
+            // eslint-disable-next-line no-restricted-syntax
+            for (const file of event.dataTransfer.files) {
+                // eslint-disable-next-line no-await-in-loop
+                await dispatch(
                     fileActions.openFile(
-                        // Electron has meddled with this type without exposing new type definition
                         (file as unknown as { path: string }).path
                     )
                 );
-            });
+            }
+
             event.preventDefault();
         };
 

--- a/src/components/CoreInfoView.tsx
+++ b/src/components/CoreInfoView.tsx
@@ -5,14 +5,16 @@
  */
 
 import React from 'react';
+import { DeviceCore } from '@nordicsemiconductor/nrf-device-lib-js';
 import PropTypes from 'prop-types';
 
+import { coreFriendlyName } from '../util/devices';
 import { hexpad8 } from '../util/hexpad';
 
 const hexpad9 = (x: number) => hexpad8(x || '');
 
 interface CoreInfoViewProps {
-    name: string;
+    name: DeviceCore;
     romBaseAddr: number;
     romSize: number;
 }
@@ -22,7 +24,7 @@ const CoreInfoView = ({ name, romBaseAddr, romSize }: CoreInfoViewProps) => (
         {name && (
             <div>
                 <h5>Core name</h5>
-                <p>{name}</p>
+                <p>{coreFriendlyName(name)}</p>
             </div>
         )}
         <div>

--- a/src/reducers/targetReducer.ts
+++ b/src/reducers/targetReducer.ts
@@ -12,8 +12,8 @@ import { Device, DfuImage } from 'pc-nrfconnect-shared';
 
 import {
     CommunicationType,
+    defaultDeviceDefinition,
     DeviceDefinition,
-    deviceDefinition,
 } from '../util/devices';
 import { Region } from '../util/regions';
 import { fileParse, filesEmpty } from './fileReducer';
@@ -44,7 +44,7 @@ const initialState: TargetState = {
     targetType: CommunicationType.UNKNOWN,
     port: undefined,
     serialNumber: undefined,
-    deviceInfo: deviceDefinition,
+    deviceInfo: defaultDeviceDefinition,
     memMap: undefined,
     regions: [],
     warnings: [],

--- a/src/util/devices.ts
+++ b/src/util/devices.ts
@@ -14,7 +14,7 @@ import nrfdl, {
 import range from './range';
 
 export type CoreDefinition = {
-    name: DeviceCore | string;
+    name: DeviceCore;
     coreNumber: number;
     romBaseAddr: number;
     romSize: number;
@@ -84,7 +84,7 @@ export const deviceDefinition: DeviceDefinition = {
  * Some information cannot be fetch by @nordicsemiconductor/nrf-device-lib-js
  * Define the default values here
  */
-const deviceDefinitions: DeviceDefinition[] = [
+export const deviceDefinitions: DeviceDefinition[] = [
     // nRF52840 dongle cannot fetch info by @nordicsemiconductor/nrf-device-lib-js
     {
         ...deviceDefinition,
@@ -131,6 +131,13 @@ const deviceDefinitions: DeviceDefinition[] = [
         ],
     },
 ];
+
+export const coreFriendlyName = (coreName: DeviceCore) =>
+    ({
+        NRFDL_DEVICE_CORE_APPLICATION: 'Application',
+        NRFDL_DEVICE_CORE_MODEM: 'Modem',
+        NRFDL_DEVICE_CORE_NETWORK: 'Network',
+    }[coreName] ?? coreName);
 
 /**
  * Nordic SoftDevice Id referring to pc-nrfutil
@@ -266,25 +273,24 @@ export const getDeviceInfoByJlink = (device: nrfdl.Device) => {
 export const addCoreToDeviceInfo = (
     deviceInfo: DeviceDefinition,
     inputCoreInfo: DeviceCoreInfo,
-    coreName: string,
+    coreName: nrfdl.DeviceCore,
     protectionStatus: ProtectionStatus
-) =>
-    ({
-        ...deviceInfo,
-        cores: [
-            ...deviceInfo.cores,
-            {
-                ...defaultCore,
-                name: coreName,
-                coreNumber: deviceInfo.cores.length,
-                romBaseAddr: inputCoreInfo.codeAddress,
-                romSize: inputCoreInfo.codeSize,
-                pageSize: inputCoreInfo.codePageSize,
-                // TODO: Check if uicrAddress is present in nrfjprog under nrf-device-lib
-                // uicrBaseAddr: inputCoreInfo.uicrAddress,
-                uicrSize: inputCoreInfo.codePageSize,
-                ...inputCoreInfo,
-                protectionStatus,
-            },
-        ],
-    } as DeviceDefinition);
+): DeviceDefinition => ({
+    ...deviceInfo,
+    cores: [
+        ...deviceInfo.cores,
+        {
+            ...defaultCore,
+            name: coreName,
+            coreNumber: deviceInfo.cores.length,
+            romBaseAddr: inputCoreInfo.codeAddress,
+            romSize: inputCoreInfo.codeSize,
+            pageSize: inputCoreInfo.codePageSize,
+            // TODO: Check if uicrAddress is present in nrfjprog under nrf-device-lib
+            uicrBaseAddr: inputCoreInfo.uicrAddress,
+            uicrSize: inputCoreInfo.codePageSize,
+            ...inputCoreInfo,
+            protectionStatus,
+        },
+    ],
+});

--- a/src/util/devices.ts
+++ b/src/util/devices.ts
@@ -66,7 +66,7 @@ export enum DeviceFamily {
 }
 
 export interface DeviceDefinition {
-    family?: DeviceFamily;
+    family: DeviceFamily;
     type?: string;
     cores: CoreDefinition[];
 }
@@ -74,7 +74,7 @@ export interface DeviceDefinition {
 /**
  * Default definition for device info
  */
-export const deviceDefinition: DeviceDefinition = {
+export const defaultDeviceDefinition: DeviceDefinition = {
     family: DeviceFamily.UNKNOWN,
     type: 'Unknown',
     cores: [defaultCore],
@@ -85,15 +85,20 @@ export const deviceDefinition: DeviceDefinition = {
  * Define the default values here
  */
 export const deviceDefinitions: DeviceDefinition[] = [
+    {
+        ...defaultDeviceDefinition,
+        family: DeviceFamily.NRF51,
+        type: 'nRF51822',
+    },
     // nRF52840 dongle cannot fetch info by @nordicsemiconductor/nrf-device-lib-js
     {
-        ...deviceDefinition,
+        ...defaultDeviceDefinition,
         family: DeviceFamily.NRF52,
         type: 'nRF52840',
     },
     // nRF9160 has different ficr and uicr base address
     {
-        ...deviceDefinition,
+        ...defaultDeviceDefinition,
         family: DeviceFamily.NRF91,
         type: 'nRF9160',
         cores: [
@@ -106,7 +111,7 @@ export const deviceDefinitions: DeviceDefinition[] = [
     },
     // nRF5340 has dual core definitions
     {
-        ...deviceDefinition,
+        ...defaultDeviceDefinition,
         family: DeviceFamily.NRF53,
         type: 'nRF5340',
         cores: [
@@ -221,7 +226,7 @@ export const getDeviceDefinition = (type: string): DeviceDefinition =>
     deviceDefinitions.find((device: DeviceDefinition) =>
         device?.type?.toLowerCase().includes(type.toLowerCase())
     ) || {
-        ...deviceDefinition,
+        ...defaultDeviceDefinition,
         type,
     };
 
@@ -249,15 +254,16 @@ export const getDeviceInfoByUSB = (
 };
 
 // Get device info by calling @nordicsemiconductor/nrf-device-lib-js
-export const getDeviceInfoByJlink = (device: nrfdl.Device) => {
-    const model = device.jlink.deviceVersion;
-    const family = device.jlink.deviceFamily;
+export const getDeviceInfoByJlink = (
+    device: nrfdl.Device
+): DeviceDefinition => {
+    const family = (device.jlink.deviceFamily ??
+        DeviceFamily.UNKNOWN) as DeviceFamily;
 
     return {
-        ...getDeviceDefinition(model),
+        ...getDeviceDefinition(family),
         family,
-        cores: [],
-    } as DeviceDefinition;
+    };
 };
 
 /**
@@ -293,4 +299,21 @@ export const addCoreToDeviceInfo = (
             protectionStatus,
         },
     ],
+});
+
+export const updateCoreInfo = (
+    existingDefinition: CoreDefinition,
+    coreNumber: number,
+    inputCoreInfo: DeviceCoreInfo,
+    protectionStatus: ProtectionStatus
+): CoreDefinition => ({
+    ...existingDefinition,
+    coreNumber,
+    romBaseAddr: inputCoreInfo.codeAddress,
+    romSize: inputCoreInfo.codeSize,
+    pageSize: inputCoreInfo.codePageSize,
+    // uicrBaseAddr: inputCoreInfo.uicrAddress,
+    uicrSize: inputCoreInfo.codePageSize,
+    ...inputCoreInfo,
+    protectionStatus,
 });

--- a/src/util/devices.ts
+++ b/src/util/devices.ts
@@ -269,38 +269,13 @@ export const getDeviceInfoByJlink = (
 /**
  * Add core info to device info
  *
- * @param {DeviceDefinition} deviceInfo - existing device info
+ * @param {DeviceDefinition} existingDefinition - existing device info
+ * @param {number} coreNumber - the number of the core
  * @param {DeviceCoreInfo} inputCoreInfo - core info to be added
- * @param {string} coreName - the name of the core
  * @param {ProtectionStatus} protectionStatus - the protection status
  *
  * @returns {DeviceDefinition} the updated device info
  */
-export const addCoreToDeviceInfo = (
-    deviceInfo: DeviceDefinition,
-    inputCoreInfo: DeviceCoreInfo,
-    coreName: nrfdl.DeviceCore,
-    protectionStatus: ProtectionStatus
-): DeviceDefinition => ({
-    ...deviceInfo,
-    cores: [
-        ...deviceInfo.cores,
-        {
-            ...defaultCore,
-            name: coreName,
-            coreNumber: deviceInfo.cores.length,
-            romBaseAddr: inputCoreInfo.codeAddress,
-            romSize: inputCoreInfo.codeSize,
-            pageSize: inputCoreInfo.codePageSize,
-            // TODO: Check if uicrAddress is present in nrfjprog under nrf-device-lib
-            uicrBaseAddr: inputCoreInfo.uicrAddress,
-            uicrSize: inputCoreInfo.codePageSize,
-            ...inputCoreInfo,
-            protectionStatus,
-        },
-    ],
-});
-
 export const updateCoreInfo = (
     existingDefinition: CoreDefinition,
     coreNumber: number,
@@ -312,7 +287,7 @@ export const updateCoreInfo = (
     romBaseAddr: inputCoreInfo.codeAddress,
     romSize: inputCoreInfo.codeSize,
     pageSize: inputCoreInfo.codePageSize,
-    // uicrBaseAddr: inputCoreInfo.uicrAddress,
+    uicrBaseAddr: inputCoreInfo.uicrAddress,
     uicrSize: inputCoreInfo.codePageSize,
     ...inputCoreInfo,
     protectionStatus,

--- a/src/util/regions.ts
+++ b/src/util/regions.ts
@@ -11,7 +11,7 @@ import { FWInfo } from '@nordicsemiconductor/nrf-device-lib-js';
 import MemoryMap, { MemoryMaps, Overlaps } from 'nrf-intel-hex';
 import { logger } from 'pc-nrfconnect-shared';
 
-import { CoreDefinition, DeviceDefinition } from './devices';
+import { CoreDefinition, coreFriendlyName, DeviceDefinition } from './devices';
 import { hexpad2 } from './hexpad';
 
 const SOFTDEVICE_MAGIC_START = 0x1000;
@@ -634,7 +634,9 @@ export const getCoreRegions = (
     memMaps: MemoryMaps,
     coreInfo: CoreDefinition
 ): Region[] => {
-    logger.info(`Parse memory regions for ${coreInfo.name} core`);
+    logger.info(
+        `Parse memory regions for ${coreFriendlyName(coreInfo.name)} core`
+    );
     const overlaps = MemoryMap.overlapMemoryMaps(memMaps);
     const regions = getRegionsFromOverlaps(overlaps, coreInfo);
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1006193/150694829-d5acb06e-6f72-4e11-9e97-2d7069411fec.png)

This pr uses the predefined cores to determine what cores a device should try to update from nrfdl-js and fall back to the predefined definitions if readback protection is enabled.

Also fixes a bug where programmer wouldnt properly remove readback protection for nrf53.