### PR TITLE
Use empty settings when no settings are found

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## 2.3.1
+### Fixed
+- Crash when settings are empty.
+
 ## 2.3.0
 ### Changed
 - Use shared code for persisting local settings in app.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-programmer",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "description": "Program a Nordic SoC with HEX files from nRF Connect",
     "displayName": "Programmer",
     "repository": {

--- a/src/store.ts
+++ b/src/store.ts
@@ -23,8 +23,7 @@ const get = store.get.bind(store);
 export const setSettings = (settings: Settings) => {
     set('settings', settings);
 };
-
-export const getSettings = () => get('settings');
+export const getSettings = () => get('settings') ?? {};
 
 export const getMruFiles = () => get('mruFiles') ?? [];
 export const setMruFiles = (files: string[]) => set('mruFiles', files);


### PR DESCRIPTION
When no settings were previously stored for the programmer, it would crash at startup, trying to read a property of undefined settings.