### PR TITLE
Show correct device version

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## 2.3.2
+### Fixed
+- Show correct version of selected device.
+
 ## 2.3.1
 ### Fixed
 - Crash when settings are empty.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-programmer",
-    "version": "2.3.0",
+    "version": "2.3.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-programmer",
-    "version": "2.3.1",
+    "version": "2.3.2",
     "description": "Program a Nordic SoC with HEX files from nRF Connect",
     "displayName": "Programmer",
     "repository": {

--- a/src/util/devices.ts
+++ b/src/util/devices.ts
@@ -8,7 +8,6 @@ import nrfdl, {
     DeviceCore,
     DeviceCoreInfo,
     ProtectionStatus,
-    // eslint-disable-next-line import/no-unresolved
 } from '@nordicsemiconductor/nrf-device-lib-js';
 
 import range from './range';
@@ -230,13 +229,15 @@ export const JLinkProductIds = [
     ...range(0x1001, 0x101f),
 ];
 
-export const getDeviceDefinition = (type: string): DeviceDefinition =>
-    deviceDefinitions.find((device: DeviceDefinition) =>
+export const getDeviceDefinition = (type: string): DeviceDefinition => {
+    const predefined = deviceDefinitions.find((device: DeviceDefinition) =>
         device?.type?.toLowerCase().includes(type.toLowerCase())
-    ) || {
-        ...defaultDeviceDefinition,
+    );
+    return {
+        ...(predefined ?? defaultDeviceDefinition),
         type,
     };
+};
 
 const getProductId = (device: nrfdl.Device) =>
     parseInt(
@@ -284,11 +285,12 @@ export const getDeviceInfoByUSB = (device: nrfdl.Device) => {
 export const getDeviceInfoByJlink = (
     device: nrfdl.Device
 ): DeviceDefinition => {
-    const family = (device.jlink.deviceFamily ??
-        DeviceFamily.UNKNOWN) as DeviceFamily;
+    const type = device.jlink.deviceVersion ?? 'Unknown';
+    const family = device.jlink.deviceFamily as DeviceFamily;
 
     return {
-        ...getDeviceDefinition(family),
+        ...getDeviceDefinition(type),
+        type,
         family,
     };
 };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1006193/152360303-4613b727-3f68-49b0-812c-6de05af89268.png)

Title would before the fix just be the predefined value from predefined values. Now it is the one we get from nrfdl-js (if any).