### PR TITLE
Cache npm packages between builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,10 +3,19 @@ trigger:
 - release/*
 pool:
   vmImage: 'Ubuntu-latest'
+variables:
+  npm_config_cache: $(Pipeline.Workspace)/.npm
 steps:
 - task: NodeTool@0
   inputs:
     versionSpec: 14
+- task: Cache@2
+  inputs:
+    key: 'npm | "$(Agent.OS)" | package-lock.json'
+    restoreKeys: |
+       npm | "$(Agent.OS)"
+    path: $(npm_config_cache)
+  displayName: Cache npm
 - script: |
     set -o errexit -o pipefail
     npm ci


### PR DESCRIPTION
Alternatively we could do something like this, https://chsamii.medium.com/azure-devops-caching-node-modules-ada6ab46af87 
Skipping npm ci all together if package-lock.json hasn't changed. But I don't know if that works with post-hooks of npm install etc.