### PR TITLE
Feat: allow updating of OB FW from Programmer app

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,8 +2,8 @@
 
 ### Added
 
--   J-Link devices OB FW can now be automatically updated when erasing, writing, and
-    reading.
+-   J-Link devices OB FW can now be automatically updated when erasing, writing,
+    and reading.
 -   Button to manually update the OB Firmware of a device.
 
 ### Changed

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,9 @@
-## 4.3.1 - Unreleased
+## 4.4.0 Unreleased
+
+### Added
+
+-   J-Link devices ONB FW can be automatically update when programming
+-   Button to Manually update OB Firmware of a device
 
 ### Changed
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,9 +2,9 @@
 
 ### Added
 
--   J-Link devices OB FW can be automatically update when Erasing, Writing and
-    Reading a JLink Device.
--   Button to Manually update OB Firmware of a device.
+-   J-Link devices OB FW can now be automatically updated when erasing, writing, and
+    reading.
+-   Button to manually update the OB Firmware of a device.
 
 ### Changed
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,8 +2,9 @@
 
 ### Added
 
--   J-Link devices ONB FW can be automatically update when programming
--   Button to Manually update OB Firmware of a device
+-   J-Link devices OB FW can be automatically update when Erasing, Writing and
+    Reading a JLink Device.
+-   Button to Manually update OB Firmware of a device.
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "4.3.1",
             "license": "SEE LICENSE IN LICENSE",
             "devDependencies": {
-                "@nordicsemiconductor/pc-nrfconnect-shared": "^170.0.0"
+                "@nordicsemiconductor/pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#feat/add-support-ob-fw-update"
             },
             "engines": {
                 "nrfconnect": ">=4.4.1"
@@ -2868,13 +2868,13 @@
             }
         },
         "node_modules/@nordicsemiconductor/pc-nrfconnect-shared": {
-            "version": "170.0.0",
-            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/pc-nrfconnect-shared/-/pc-nrfconnect-shared-170.0.0.tgz",
-            "integrity": "sha512-mZMPYpJRkqjwb74ueA2cHsR8HZVRboXeIvqfL8aScBUKRyC1aMEeV8JPCwxRVvM4FArWKUz9WOgWxuJtGNUUTA==",
+            "version": "178.0.0",
+            "resolved": "git+ssh://git@github.com/NordicSemiconductor/pc-nrfconnect-shared.git#a7d2c778317990c4982f38a90f391abad34b46d3",
             "dev": true,
             "hasInstallScript": true,
+            "license": "ISC",
             "dependencies": {
-                "@electron/remote": "^2.1.1",
+                "@electron/remote": "^2.1.2",
                 "@mdi/font": "7.2.96",
                 "@mdi/js": "^7.2.96",
                 "@mdi/react": "^1.6.1",
@@ -2907,7 +2907,7 @@
                 "bootstrap": "4.6.2",
                 "commander": "10.0.0",
                 "date-fns": "2.29.3",
-                "electron": "^28.1.4",
+                "electron": "^30.0.2",
                 "electron-store": "8.1.0",
                 "esbuild": "0.19.2",
                 "esbuild-sass-plugin": "2.13.0",
@@ -4441,10 +4441,13 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.5.7",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.7.tgz",
-            "integrity": "sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA==",
-            "dev": true
+            "version": "20.12.12",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+            "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
         },
         "node_modules/@types/normalize-package-data": {
             "version": "2.4.1",
@@ -6817,14 +6820,14 @@
             "dev": true
         },
         "node_modules/electron": {
-            "version": "28.2.2",
-            "resolved": "https://registry.npmjs.org/electron/-/electron-28.2.2.tgz",
-            "integrity": "sha512-8UcvIGFcjplHdjPFNAHVFg5bS0atDyT3Zx21WwuE4iLfxcAMsyMEOgrQX3im5LibA8srwsUZs7Cx0JAUfcQRpw==",
+            "version": "30.0.8",
+            "resolved": "https://registry.npmjs.org/electron/-/electron-30.0.8.tgz",
+            "integrity": "sha512-ivzXJJ/9gdb4oOw+5SDuaZpSInz8C+Z021dKZfFLMltKbDa4sSqt5cRBiUg7J36Z2kdus+Jai0bdHWutYE9wAA==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
                 "@electron/get": "^2.0.0",
-                "@types/node": "^18.11.18",
+                "@types/node": "^20.9.0",
                 "extract-zip": "^2.0.1"
             },
             "bin": {
@@ -6852,15 +6855,6 @@
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.507.tgz",
             "integrity": "sha512-brvPFnO1lu3UYBpBht2qWw9qqhdG4htTjT90/9oOJmxQ77VvTxL9+ghErFqQzgj7n8268ONAmlebqjBR/S+qgA==",
             "dev": true
-        },
-        "node_modules/electron/node_modules/@types/node": {
-            "version": "18.19.15",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.15.tgz",
-            "integrity": "sha512-AMZ2UWx+woHNfM11PyAEQmfSxi05jm9OlkxczuHeEqmvwPkYj6MWv44gbzDPefYOLysTOFyI3ziiy2ONmUZfpA==",
-            "dev": true,
-            "dependencies": {
-                "undici-types": "~5.26.4"
-            }
         },
         "node_modules/emitter-listener": {
             "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pc-nrfconnect-programmer",
-    "version": "4.3.1",
+    "version": "4.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "pc-nrfconnect-programmer",
-            "version": "4.3.1",
+            "version": "4.4.0",
             "license": "SEE LICENSE IN LICENSE",
             "devDependencies": {
                 "@nordicsemiconductor/pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#feat/add-support-ob-fw-update"
@@ -2869,7 +2869,7 @@
         },
         "node_modules/@nordicsemiconductor/pc-nrfconnect-shared": {
             "version": "178.0.0",
-            "resolved": "git+ssh://git@github.com/NordicSemiconductor/pc-nrfconnect-shared.git#a7d2c778317990c4982f38a90f391abad34b46d3",
+            "resolved": "git+ssh://git@github.com/NordicSemiconductor/pc-nrfconnect-shared.git#d5053d469d948db07d0c2833d8fa11c1b50739dc",
             "dev": true,
             "hasInstallScript": true,
             "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "nrfConnectForDesktop": {
         "nrfutil": {
             "device": [
-                "2.1.1"
+                "2.3.5"
             ]
         },
         "html": "dist/index.html"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-programmer",
-    "version": "4.3.1",
+    "version": "4.4.0",
     "displayName": "Programmer",
     "description": "Tool for flash programming Nordic SoCs and SiPs",
     "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-programmer",
@@ -46,7 +46,7 @@
         "prepare": "husky install"
     },
     "devDependencies": {
-        "@nordicsemiconductor/pc-nrfconnect-shared": "^170.0.0"
+        "@nordicsemiconductor/pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#feat/add-support-ob-fw-update"
     },
     "eslintConfig": {
         "extends": "./node_modules/@nordicsemiconductor/pc-nrfconnect-shared/config/eslintrc"

--- a/src/actions/jlinkTargetActions.ts
+++ b/src/actions/jlinkTargetActions.ts
@@ -421,7 +421,7 @@ export const updateOBFirmware =
                 );
             } else {
                 logger.info(
-                    `J-Link OB firmware version was updated to ${result.versionAfterUpdate}.`
+                    `J-Link OB firmware version updated to ${result.versionAfterUpdate}.`
                 );
             }
         });

--- a/src/actions/jlinkTargetActions.ts
+++ b/src/actions/jlinkTargetActions.ts
@@ -10,7 +10,6 @@ import {
     describeError,
     Device,
     logger,
-    setWaitForDevice,
 } from '@nordicsemiconductor/pc-nrfconnect-shared';
 import {
     BatchCallbacks,
@@ -411,33 +410,21 @@ export const recover =
 
 export const updateOBFirmware =
     (device: Device): AppThunk<RootState, Promise<void>> =>
-    async dispatch => {
-        dispatch(
-            setWaitForDevice({
-                timeout: 30000,
-                when: 'always',
-                once: false,
-            })
-        );
-        logger.info(`Updating OB Firmware`);
-        await NrfutilDeviceLib.updateDebugProbeFirmware(device).then(result => {
+    dispatch => {
+        logger.info(`Updating J-Link OB firmware.`);
+        return dispatch(
+            NrfutilDeviceLib.updateOBFirmwareWithWaitForDevice(device)
+        ).then(result => {
             if (result.versionAfterUpdate === result.versionBeforeUpdate) {
                 logger.info(
-                    `No OB version update was required. OB version is at ${result.versionAfterUpdate}.`
+                    `No J-Link OB firmware update was required. Version is at ${result.versionAfterUpdate}.`
                 );
             } else {
                 logger.info(
-                    `OB version was updated to ${result.versionAfterUpdate}.`
+                    `J-Link OB firmware version was updated to ${result.versionAfterUpdate}.`
                 );
             }
         });
-        dispatch(
-            setWaitForDevice({
-                timeout: 30000,
-                when: 'always',
-                once: true,
-            })
-        );
     };
 
 export const recoverAndWrite =

--- a/src/actions/settingsActions.ts
+++ b/src/actions/settingsActions.ts
@@ -10,6 +10,7 @@ import {
     settingsLoad,
     toggleAutoRead as toggleAutoReadAction,
     toggleAutoReset as toggleAutoResetAction,
+    toggleAutoUpdateOBFirmware as toggleAutoUpdateOBFirmwareAction,
 } from '../reducers/settingsReducer';
 import { RootState } from '../reducers/types';
 import { getSettings, setSettings } from '../store';
@@ -28,6 +29,19 @@ export const loadSettings = (): AppThunk => dispatch => {
     setSettings(settings);
     dispatch(settingsLoad({ ...settings, forceMcuBoot: false }));
 };
+
+export const toggleAutoUpdateOBFirmware =
+    (): AppThunk<RootState> => (dispatch, getState) => {
+        dispatch(toggleAutoUpdateOBFirmwareAction());
+        const settings = getSettings();
+
+        // Do not use async functions above，
+        // otherwise the state would be the same as before toggling
+        setSettings({
+            ...settings,
+            autoUpdateOBFirmware: getState().app.settings.autoUpdateOBFirmware,
+        });
+    };
 
 export const toggleAutoRead =
     (): AppThunk<RootState> => (dispatch, getState) => {

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -391,7 +391,7 @@ Are you sure you want to continue?`,
                     }
                     title={
                         isJLink && !zipFile
-                            ? 'The Write operation is not supported for JLink devices. Use Erase & write.'
+                            ? 'The write operation is not supported for J-Link devices. Use Erase & write instead.'
                             : ''
                     }
                 >
@@ -433,7 +433,7 @@ Are you sure you want to continue?`,
                 <Toggle
                     onToggle={() => dispatch(settingsActions.toggleAutoRead())}
                     isToggled={autoRead}
-                    label="Auto read memory"
+                    label="Automatic memory read"
                     barColor={colors.gray700}
                     handleColor={colors.gray300}
                 />
@@ -445,10 +445,10 @@ Are you sure you want to continue?`,
                     handleColor={colors.gray300}
                 >
                     <>
-                        Auto reset
+                        Automatic device reset
                         {isJLink && isModem && autoReset && (
                             <span
-                                title="Resetting modem too many times might cause it to lock up, use this setting with care for devices with modem."
+                                title="Use this setting with care for devices with modem: resetting it too many times might cause it to lock up."
                                 className="mdi mdi-alert"
                             />
                         )}
@@ -459,7 +459,7 @@ Are you sure you want to continue?`,
                         dispatch(settingsActions.toggleAutoUpdateOBFirmware())
                     }
                     isToggled={autoUpdateOBFirmware}
-                    label="OB Firmware automatic update"
+                    label="OB FW automatic update"
                     barColor={colors.gray700}
                     handleColor={colors.gray300}
                     title="Update the debug probe firmware when erasing, writing, or reading."

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -459,10 +459,10 @@ Are you sure you want to continue?`,
                         dispatch(settingsActions.toggleAutoUpdateOBFirmware())
                     }
                     isToggled={autoUpdateOBFirmware}
-                    label="Auto update OB Firmware"
+                    label="OB Firmware automatic update"
                     barColor={colors.gray700}
                     handleColor={colors.gray300}
-                    title="Update debug probe firmware when Erasing, Writing or reading the device"
+                    title="Update the debug probe firmware when erasing, writing, or reading."
                 />
             </Group>
             <Group heading="MCUboot Settings">

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -312,7 +312,7 @@ Are you sure you want to continue?`,
                     disabled={isMcuboot || !isJLink || !targetIsReady}
                 >
                     <span className="mdi mdi-update" />
-                    Update OB Firmware
+                    Update J-Link OB Firmware
                 </Button>
                 <Button
                     variant="secondary"

--- a/src/reducers/settingsReducer.ts
+++ b/src/reducers/settingsReducer.ts
@@ -19,7 +19,7 @@ const initialState: SettingsState = {
     forceMcuBoot: false,
     autoRead: false,
     autoReset: false,
-    autoUpdateOBFirmware: true,
+    autoUpdateOBFirmware: false,
 };
 
 const settingsSlice = createSlice({

--- a/src/reducers/settingsReducer.ts
+++ b/src/reducers/settingsReducer.ts
@@ -29,6 +29,7 @@ const settingsSlice = createSlice({
         settingsLoad(state, action: PayloadAction<SettingsState>) {
             state.autoRead = action.payload.autoRead;
             state.autoReset = action.payload.autoReset;
+            state.autoUpdateOBFirmware = action.payload.autoUpdateOBFirmware;
         },
         toggleAutoRead(state) {
             state.autoRead = !state.autoRead;

--- a/src/reducers/settingsReducer.ts
+++ b/src/reducers/settingsReducer.ts
@@ -12,12 +12,14 @@ export interface SettingsState {
     forceMcuBoot: boolean;
     autoRead: boolean;
     autoReset: boolean;
+    autoUpdateOBFirmware: boolean;
 }
 
 const initialState: SettingsState = {
     forceMcuBoot: false,
     autoRead: false,
     autoReset: false,
+    autoUpdateOBFirmware: true,
 };
 
 const settingsSlice = createSlice({
@@ -34,14 +36,29 @@ const settingsSlice = createSlice({
         toggleAutoReset(state) {
             state.autoReset = !state.autoReset;
         },
+        toggleAutoUpdateOBFirmware(state) {
+            state.autoUpdateOBFirmware = !state.autoUpdateOBFirmware;
+        },
     },
 });
 
 export default settingsSlice.reducer;
 
-const { settingsLoad, toggleAutoRead, toggleAutoReset } = settingsSlice.actions;
+const {
+    settingsLoad,
+    toggleAutoRead,
+    toggleAutoReset,
+    toggleAutoUpdateOBFirmware,
+} = settingsSlice.actions;
 
-export { settingsLoad, toggleAutoRead, toggleAutoReset };
+export {
+    settingsLoad,
+    toggleAutoRead,
+    toggleAutoReset,
+    toggleAutoUpdateOBFirmware,
+};
 
 export const getAutoRead = (state: RootState) => state.app.settings.autoRead;
 export const getAutoReset = (state: RootState) => state.app.settings.autoReset;
+export const getAutoUpdateOBFirmware = (state: RootState) =>
+    state.app.settings.autoUpdateOBFirmware;

--- a/src/store.ts
+++ b/src/store.ts
@@ -14,6 +14,7 @@ interface StoreSchema {
 interface Settings {
     autoRead: boolean;
     autoReset: boolean;
+    autoUpdateOBFirmware: boolean;
 }
 
 const store = getPersistentStore<StoreSchema>();


### PR DESCRIPTION
This PR add the ability in programme to update the J-Link OB Firmware.

This can be done in two ways:
-  Auto with every read, write and erase (will effect performance) default is for this option is off @bihanssen  any suggestions?
- Manually with a button

Auto UI (image updated)

<img width="231" alt="image" src="https://github.com/NordicSemiconductor/pc-nrfconnect-programmer/assets/10996496/55cdfe1d-06ea-4411-9b1d-294a42436feb">


Manual UI

<img width="249" alt="image" src="https://github.com/NordicSemiconductor/pc-nrfconnect-programmer/assets/10996496/034c127c-1de0-43ab-a2b5-49caac2869d9">


Result in Logger

<img width="663" alt="image" src="https://github.com/NordicSemiconductor/pc-nrfconnect-programmer/assets/10996496/313d3256-15bb-4d18-b313-3ff5ffcc13f9">

<img width="837" alt="image" src="https://github.com/NordicSemiconductor/pc-nrfconnect-programmer/assets/10996496/9b57fb92-4701-4dfd-aa00-1657ac87f6e6">

@greg-fer  if this is approve then Docs will need updating
@ketile  let me know if UI is OK
