### PR TITLE
Fix/warning hex out of memory uicr

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+## 4.4.1 - Unreleased
+
+### Fixed
+
+-   Invalid warning `Hex reguons are out of device memory size` for Hex files
+    with UICR.
+
 ## 4.4.0 - 2024-06-13
 
 ### Added

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,8 +2,8 @@
 
 ### Fixed
 
--   Invalid warning `Hex reguons are out of device memory size` for Hex files
-    with UICR.
+-   Invalid warning `HEX regions are out of device memory size` for HEX files
+    with UICR will not be displayed anymore.
 -   The SoC is now detected before each operation to ensure the app works even
     if the SoC changes between operations.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-programmer",
-    "version": "4.4.0",
+    "version": "4.4.1",
     "displayName": "Programmer",
     "description": "Tool for flash programming Nordic SoCs and SiPs",
     "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-programmer",

--- a/src/actions/jlinkTargetActions.ts
+++ b/src/actions/jlinkTargetActions.ts
@@ -301,7 +301,7 @@ const geCoreHexIntel = (
             overlapEndAddr <= coreInfo.romBaseAddr + coreInfo.romSize;
         const isUicr =
             overlapStartAddr >= coreInfo.uicrBaseAddr &&
-            overlapEndAddr <= coreInfo.uicrBaseAddr + coreInfo.pageSize;
+            overlapEndAddr <= coreInfo.uicrBaseAddr + coreInfo.uicrSize;
         if (!isInCore && !isUicr) {
             overlaps.delete(key);
         }

--- a/src/components/FileMemoryView.tsx
+++ b/src/components/FileMemoryView.tsx
@@ -84,9 +84,12 @@ export default () => {
                 const allRegions = generateFileRegions(memMaps, coreInfo);
                 const validRegions = allRegions.filter(
                     r =>
-                        r.startAddress >= coreInfo.romBaseAddr &&
-                        r.startAddress + r.regionSize <=
-                            coreInfo.romBaseAddr + coreInfo.romSize
+                        (r.startAddress >= coreInfo.romBaseAddr &&
+                            r.startAddress + r.regionSize <=
+                                coreInfo.romBaseAddr + coreInfo.romSize) ||
+                        (r.startAddress >= coreInfo.uicrBaseAddr &&
+                            r.startAddress + r.regionSize <=
+                                coreInfo.uicrBaseAddr + coreInfo.uicrSize)
                 );
 
                 if (validRegions.length !== allRegions.length) {

--- a/src/util/devices.ts
+++ b/src/util/devices.ts
@@ -29,9 +29,9 @@ export const defaultCore: CoreDefinition = {
     pageSize: 0x1000, // 4 KB
     blockSize: 0x200, // 0.5 KB
     ficrBaseAddr: 0x10000000,
-    ficrSize: 0x400, // Todo: check and make sure!
+    ficrSize: 0x1000,
     uicrBaseAddr: 0x10001000,
-    uicrSize: 0x400, // Todo: check and make sure!
+    uicrSize: 0x1000,
     blAddrOffset: 0x14,
     mbrParamsOffset: 0x18,
     mbrBaseAddr: 0x0,


### PR DESCRIPTION
This PR fixes:

![image](https://github.com/user-attachments/assets/121b66bc-e84a-498e-9678-b479b3c7fdfd)


UICR and FICR size have been verified from the svd files 