### PR TITLE
doc: rename app + other edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# nRF Connect Programmer
+# Programmer app
 
 [![Build Status](https://dev.azure.com/NordicSemiconductor/Wayland/_apis/build/status/NordicSemiconductor.pc-nrfconnect-programmer?branchName=main)](https://dev.azure.com/NordicSemiconductor/Wayland/_build/latest?definitionId=4&branchName=main)
 [![License](https://img.shields.io/badge/license-Modified%20BSD%20License-blue.svg)](LICENSE)
 
-nRF Connect Programmer is a cross-platform tool that enables programming
+The Programmer app is a cross-platform tool that enables programming
 firmware to Nordic Semiconductor devices and custom devices that use Nordic
 Semiconductor hardware.
 
@@ -15,7 +15,7 @@ the firmware files and the devices.
 
 ## Installation
 
-nRF Connect Programmer is installed from nRF Connect from Desktop. For detailed
+The Programmer app is installed from nRF Connect from Desktop. For detailed
 steps, see
 [Installing nRF Connect for Desktop apps](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/installing_apps.html)
 in the nRF Connect from Desktop documentation.
@@ -23,7 +23,7 @@ in the nRF Connect from Desktop documentation.
 ## Documentation
 
 Read the
-[nRF Connect Programmer](https://docs.nordicsemi.com/bundle/nrf-connect-programmer/page/index.html)
+[Programmer app](https://docs.nordicsemi.com/bundle/nrf-connect-programmer/page/index.html)
 official documentation, which includes information about the
 [application UI](https://docs.nordicsemi.com/bundle/nrf-connect-programmer/page/overview.html)
 and

--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -1,10 +1,10 @@
-# nRF Connect Programmer
+# {{app_name}}
 
-nRF Connect Programmer is an app available from [nRF Connect for Desktop](https://nordic-dev.zoominsoftware.io/bundle/nrf-connect-desktop/page/index.html) that you can use to program firmware to Nordic devices. The application allows you to see the memory layout for devices that support programming with J-Link, Nordic Secure DFU, and MCUboot. It also allows you to display content of HEX files and write it to the devices.
+The {{app_name}} in [nRF Connect for Desktop](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/index.html) lets you program firmware to Nordic devices. The application allows you to see the memory layout for devices that support programming with J-Link, Nordic Secure DFU, and MCUboot. It also allows you to display content of HEX files and write it to the devices.
 
 ## Supported hardware
 
-The following table lists the hardware platforms that you can program with nRF Connect Programmer.
+The following table lists the hardware platforms that you can program with the {{app_name}}.
 
 | Hardware platform   | Device   | PCA number | Programming with J-Link  | Programming with Nordic Secure DFU  | Programming with MCUboot |
 |---------------------|----------|------------|--------------------------|-------------------------------------|--------------------------|
@@ -25,16 +25,16 @@ Programming with Nordic Secure DFU is **Possible** on some nRF52 Series platform
 
 ### Support for custom hardware
 
-The following criteria apply to programming custom hardware with nRF Connect Programmer:
+The following criteria apply to programming custom hardware with the {{app_name}}:
 
 - **Device**: The hardware platform you are programming must use an SoC or SiP from Nordic Semiconductor.
 - **Programming with J-Link**: Possible for all custom hardware that features Nordic SoCs supported by [nRF Util](https://docs.nordicsemi.com/bundle/nrfutil/page/README.html).
-- **Programming with Nordic Secure DFU**: Possible if you implement a bootloader solution that supports Nordic Secure DFU. nRF Connect Programmer checks the bootloader for Nordic ID to be able to program using this method.
+- **Programming with Nordic Secure DFU**: Possible if you implement a bootloader solution that supports Nordic Secure DFU. The {{app_name}} checks the bootloader for Nordic ID to be able to program using this method.
 - **Programming with MCUboot**: Only possible using CLI.
 
 ## Deprecated hardware support
 
-The following hardware platforms cannot be programmed with nRF Connect Programmer anymore.
+The following hardware platforms cannot be programmed with the {{app_name}} anymore.
 
 | Hardware platform   | Device   | PCA number | Programming with J-Link  | Programming with Nordic Secure DFU  | Programming with MCUboot |
 |---------------------|----------|------------|--------------------------|-------------------------------------|--------------------------|

--- a/doc/docs/installing.md
+++ b/doc/docs/installing.md
@@ -1,3 +1,3 @@
-# Installing the Programmer app
+# Installing the {{app_name}}
 
 For installation instructions, see [Installing nRF Connect for Desktop apps](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/installing_apps.html) in the nRF Connect for Desktop documentation.

--- a/doc/docs/overview.md
+++ b/doc/docs/overview.md
@@ -1,10 +1,10 @@
 # Overview and user interface
 
-The nRF Connect Programmer app main window displays the memory layout of the device and the file you want to work with. It also provides options to program the device and inspect the entire process through the log.
+The {{app_name}} main window displays the memory layout of the device and the file you want to work with. It also provides options to program the device and inspect the entire process through the log.
 
 When you start the Programmer app, the application main window appears with the **Programmer** tab selected by default and the [**File Memory Layout**](#file-memory-layout) and [**Device Memory Layout**](#device-memory-layout) panels empty:
 
-![nRF Connect Programmer default view at startup](./screenshots/programmer_overview.png "nRF Connect Programmer main window")
+![{{app_name}} default view at startup](./screenshots/programmer_overview.png "{{app_name}} main window")
 
 ## Select Device
 
@@ -48,7 +48,7 @@ When you select a device, the following toggles are available in the J-Link Sett
 
 ### MCUboot Settings
 
-The experimental **Enable MCUBoot** toggle is deprecated and will be removed in a future release of nRF Connect Programmer.
+The experimental **Enable MCUBoot** toggle is deprecated and will be removed in a future release of the {{app_name}}.
 
 ## Programmer tab
 
@@ -76,7 +76,7 @@ In the **Device Memory Layout**, you can read the name, address range, and size 
 
 You can view application information, restore defaults, access source code and documentation. You also can find information on the selected device, access support tools, send feedback, and enable verbose logging.
 
-![nRF Connect for Desktop Programmer About tab](./screenshots/nRF_Connect_for_Desktop_Prog_about.png "nRF Connect for Desktop Programmer About tab")
+![{{app_name}} About tab](./screenshots/nRF_Connect_for_Desktop_Prog_about.png "{{app_name}} About tab")
 
 ## Log
 

--- a/doc/docs/programming_dk.md
+++ b/doc/docs/programming_dk.md
@@ -1,9 +1,9 @@
 # Programming devices
 
-In nRF Connect Programmer, you can program [supported devices](index.md#supported-devices) or a custom board with a supported chip that allows for communication with J-Link, Nordic Secure DFU devices, and MCUboot devices.
+In the {{app_name}}, you can program [supported devices](index.md#supported-devices) or a custom board with a supported chip that allows for communication with J-Link, Nordic Secure DFU devices, and MCUboot devices.
 
 !!! tip "Tip"
-      If you experience any problems during the programming process, press Ctrl-R (command-R on macOS) to restart the nRF Connect Programmer app, and try programming again.
+      If you experience any problems during the programming process, press Ctrl-R (command-R on macOS) to restart the {{app_name}}, and try programming again.
 
 ## Device-specific procedures
 
@@ -21,7 +21,7 @@ The following devices have specific programming requirements or procedures:
 
 To program a supported development kit, complete the following procedure:
 
-1. Open nRF Connect for Desktop and launch **nRF Connect Programmer**.
+1. Open nRF Connect for Desktop and launch the {{app_name}}.
 2. Connect a development kit to the computer with a USB cable and turn it on.
 3. Click **Select device** and choose the device from the drop-down list.</br>
    The button text changes to the name and serial number of the selected device, and the **Device Memory Layout** section indicates that the device is connected.
@@ -43,7 +43,7 @@ To program a supported development kit, complete the following procedure:
 
 To program the nRF52840 Dongle, complete the following steps:
 
-1. Open nRF Connect for Desktop and launch nRF Connect Programmer.
+1. Open nRF Connect for Desktop and launch the {{app_name}}.
 2. Insert the nRF52840 Dongle into a USB port on the computer.
 3. Put the dongle into bootloader mode by pressing the **RESET** button.
 

--- a/doc/docs/revision_history.md
+++ b/doc/docs/revision_history.md
@@ -2,6 +2,7 @@
 
 | Date       | Description                                                                                                                                                                                  |
 |------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| November 2024   | Editorial changes |
 | May 2024   | Editorial changes |
 | March 2024 | Updated the documentation for the [nRF Connect Programmer v4.3.0](https://github.com/NordicSemiconductor/pc-nrfconnect-programmer/blob/main/Changelog.md)                                               |
 | February 2024  | Updated the [supported devices section](index.md#supported-devices) with a matrix table                                               |

--- a/doc/docs/troubleshooting.md
+++ b/doc/docs/troubleshooting.md
@@ -10,7 +10,7 @@ In OS X: An issue with the SEGGER J-Link OB firmware leads to the corruption of 
 
 ## Serial Port Access Permissions on Ubuntu Linux
 
-If you receive errors when trying to open the serial port in the nRF Connect Bluetooth Low Energy app on Ubuntu Linux, you may need to grant serial port access permissions to your user. To do this, run the following command:
+If you receive errors when trying to open the serial port in the {{app_name}} on Ubuntu Linux, you may need to grant serial port access permissions to your user. To do this, run the following command:
 
 ```
 sudo usermod -a -G dialout <username>

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: nRF Connect Programmer documentation
+site_name: Programmer app documentation
 site_url:
 use_directory_urls: false
 
@@ -30,7 +30,7 @@ extra_css:
   - stylesheets/style.css
 
 copyright:
-  Copyright &copy; 2023
+  Copyright &copy; 2019-2024
 
 markdown_extensions:
   - abbr
@@ -42,9 +42,6 @@ markdown_extensions:
   - pymdownx.keys
   - pymdownx.tabbed
   - pymdownx.superfences
-  - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
   - toc:
       permalink: true
       toc_depth: 4
@@ -56,6 +53,7 @@ plugins:
 
 extra:
   test: This is a test abbreviation snippet
+  app_name: Programmer app
 
 nav:
   - Home: index.md

--- a/doc/zoomin/custom.properties
+++ b/doc/zoomin/custom.properties
@@ -1,3 +1,3 @@
 manual.name=nrf-connect-programmer
-booktitle=nRF Connect Programmer
-shortdesc=Documentation for the nRF Connect Programmer application.
+booktitle=Programmer app
+shortdesc=Documentation for the Programmer application.


### PR DESCRIPTION
Dropped nRF Connect from app name.
Updated copyright year.
Removed unused extensions.
Added app_name abbreviation.
NCD-1066.