### PR TITLE
doc: LM20 typos fix

### DIFF
--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -15,7 +15,7 @@ The following table lists the hardware platforms that you can program with the {
 | nRF9151 DK          | nRF9131  | PCA10171   | Yes                      | No                                  | No                       |
 | nRF9131 DK          | nRF9131  | PCA10147   | Yes                      | No                                  | No                       |
 | nRF54H20 DK         | nRF54H20 | PCA10175   | *Not yet available*      | No                                  | No                       |
-| nRF54LM20A DK       | nRF54L20 | PCA10184   | Yes                      | No                                  | No                       |
+| nRF54LM20 DK        | nRF54LM20| PCA10184   | Yes                      | No                                  | No                       |
 | nRF54L15 DK         | nRF54L15 | PCA10156   | Yes                      | No                                  | No                       |
 | nRF5340 DK          | nRF5340  | PCA10095   | Yes                      | No                                  | No                       |
 | nRF5340 Audio DK    | nRF5340  | PCA10121   | Yes                      | No                                  | No                       |


### PR DESCRIPTION
Fixed typos in the DK and device name.