### PR TITLE
chore: point workflows and package URLs to nordicsemi org

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
     build:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/build-app.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/build-app.yml@main

--- a/.github/workflows/docs-bundle.yml
+++ b/.github/workflows/docs-bundle.yml
@@ -11,6 +11,6 @@ on:
 
 jobs:
     create-doc-bundle:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/docs-bundle.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/docs-bundle.yml@main
         with:
             bundle-name: nrf-connect-programmer

--- a/.github/workflows/docs-publish-dev.yml
+++ b/.github/workflows/docs-publish-dev.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
     publish-docs-bundle:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/docs-publish.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/docs-publish.yml@main
         with:
             bundle-name: nrf-connect-programmer
             release-type: dev

--- a/.github/workflows/docs-publish-prod.yml
+++ b/.github/workflows/docs-publish-prod.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     publish-docs-bundle:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/docs-publish.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/docs-publish.yml@main
         with:
             bundle-name: nrf-connect-programmer
             release-type: prod

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -10,5 +10,5 @@ on:
 
 jobs:
     check_labels:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/labels.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/labels.yml@main
         secrets: inherit

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     release:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/release-app.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/release-app.yml@main
         with:
             source: latest (internal)
         secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
     release:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/release-app.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/release-app.yml@main
         with:
             source: ${{ inputs.source }}
             ref: ${{ inputs.ref }}

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ and
 
 ## Development
 
-See the
-[app development](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/)
+See the [app development](https://nordicsemi.github.io/pc-nrfconnect-docs/)
 pages for details on how to develop apps for the nRF Connect for Desktop
 framework.
 
@@ -43,7 +42,7 @@ Please report issues on the [DevZone](https://devzone.nordicsemi.com) portal.
 ## Contributing
 
 See the
-[information on contributing](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/contributing)
+[information on contributing](https://nordicsemi.github.io/pc-nrfconnect-docs/contributing)
 for details.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Programmer app
 
-[![Build Status](https://dev.azure.com/NordicSemiconductor/Wayland/_apis/build/status/NordicSemiconductor.pc-nrfconnect-programmer?branchName=main)](https://dev.azure.com/NordicSemiconductor/Wayland/_build/latest?definitionId=4&branchName=main)
 [![License](https://img.shields.io/badge/license-Modified%20BSD%20License-blue.svg)](LICENSE)
 
 The Programmer app is a cross-platform tool that enables programming firmware to

--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -57,5 +57,5 @@ The following hardware platforms cannot be programmed with the Programmer app an
 
 ## Application source code
 
-The code of the application is open source and [available on GitHub](https://github.com/NordicSemiconductor/pc-nrfconnect-programmer).
+The code of the application is open source and [available on GitHub](https://github.com/nordicsemi/pc-nrfconnect-programmer).
 Feel free to fork the repository and clone it for secondary development or feature contributions.

--- a/doc/docs/revision_history.yml
+++ b/doc/docs/revision_history.yml
@@ -31,16 +31,16 @@ sections:
   - "Editorial changes."
 - name: March 2024
   entries:
-  - "Updated the documentation for the [nRF Connect Programmer v4.3.0](https://github.com/NordicSemiconductor/pc-nrfconnect-programmer/blob/main/Changelog.md)."
+  - "Updated the documentation for the [nRF Connect Programmer v4.3.0](https://github.com/nordicsemi/pc-nrfconnect-programmer/blob/main/Changelog.md)."
 - name: February 2024
   entries:
   - "Updated the [supported hardware section](index.md#supported-hardware) with a matrix table."
 - name: January 2024
   entries:
-  - "Updated the documentation for the [nRF Connect Programmer v4.2.0](https://github.com/NordicSemiconductor/pc-nrfconnect-programmer/blob/main/Changelog.md)."
+  - "Updated the documentation for the [nRF Connect Programmer v4.2.0](https://github.com/nordicsemi/pc-nrfconnect-programmer/blob/main/Changelog.md)."
 - name: September 2022
   entries:
-  - "Updated images and text for new user interface in [nRF Connect Programmer v3.0.3](https://github.com/NordicSemiconductor/pc-nrfconnect-programmer/blob/main/Changelog.md#303---2022-06-17)."
+  - "Updated images and text for new user interface in [nRF Connect Programmer v3.0.3](https://github.com/nordicsemi/pc-nrfconnect-programmer/blob/main/Changelog.md#303---2022-06-17)."
 - name: February 2022
   entries:
   - "Removed nRF9160 DK related content. Removed content is found in [Getting started with nRF9160 DK](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/device_guides/working_with_nrf/nrf91/nrf9160_gs.html)."
@@ -66,7 +66,7 @@ sections:
   - "Added Programming Nordic Thingy:91."
 - name: September 2019
   entries:
-  - "Updated to match [nRF Connect Programmer v1.2.3](https://github.com/NordicSemiconductor/pc-nrfconnect-programmer/blob/main/Changelog.md#123---2019-08-30)."
+  - "Updated to match [nRF Connect Programmer v1.2.3](https://github.com/nordicsemi/pc-nrfconnect-programmer/blob/main/Changelog.md#123---2019-08-30)."
   - "Added Programming the nRF9160 DK cellular modem."
   - "Updated [Overview and user interface](overview.md)."
   - "Updated [Installing the Programmer app](index.md#installing-the-programmer-app)."

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
     "version": "4.7.3",
     "displayName": "Programmer",
     "description": "Tool for flash programming Nordic SoCs and SiPs",
-    "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-programmer",
+    "homepage": "https://github.com/nordicsemi/pc-nrfconnect-programmer",
     "repository": {
         "type": "git",
-        "url": "https://github.com/NordicSemiconductor/pc-nrfconnect-programmer.git"
+        "url": "https://github.com/nordicsemi/pc-nrfconnect-programmer.git"
     },
     "author": "Nordic Semiconductor ASA",
     "license": "SEE LICENSE IN LICENSE",

--- a/src/actions/targetActions.ts
+++ b/src/actions/targetActions.ts
@@ -44,13 +44,13 @@ export const openDevice =
                 if (process.platform === 'linux') {
                     logger.warn(
                         'If the device is a JLink device, please make sure J-Link Software and nrf-udev are installed. ' +
-                            'See https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/#macos-and-linux',
+                            'See https://github.com/nordicsemi/pc-nrfconnect-launcher/#macos-and-linux',
                     );
                 }
                 if (process.platform === 'darwin') {
                     logger.warn(
                         'If the device is a JLink device, please make sure J-Link Software is installed. ' +
-                            'See https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/#macos-and-linux',
+                            'See https://github.com/nordicsemi/pc-nrfconnect-launcher/#macos-and-linux',
                     );
                 }
             }


### PR DESCRIPTION
Update reusable workflow references and repository homepage/URL from NordicSemiconductor to nordicsemi.

## Summary

Updates all reusable workflow `uses:` paths from `NordicSemiconductor/pc-nrfconnect-shared` to `nordicsemi/pc-nrfconnect-shared` to match the enterprise organization naming.

`package.json` `homepage` and `repository.url` point at the canonical **nordicsemi** org (not the former NordicSemiconductor naming).

## Notes

No functional workflow logic changes; only the repository path in composite/reusable workflow references, plus `package.json` metadata for the official GitHub location.